### PR TITLE
feat: add follow subcommand

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -254,6 +254,24 @@ program
     process.stdout.write(stringify(posts, { lineWidth: 120 }))
   })
 
+// follow: Follow a user
+program
+  .command("follow")
+  .description("Follow a user by handle")
+  .argument("<handle>", "User handle (e.g. cameron.stream, @cpfiffer.bsky.social)")
+  .option("-p, --platform <platform>", "Platform", "bsky")
+  .action(async (handle, opts) => {
+    const { getPlatformAsync } = await import("./platforms/index.js")
+    const platform = await getPlatformAsync(opts.platform)
+    if (!platform.follow) {
+      console.error(`Platform ${opts.platform} does not support follow`)
+      process.exit(1)
+    }
+    const cleanHandle = handle.replace(/^@/, "")
+    await platform.follow(cleanHandle)
+    console.log(`Followed: ${cleanHandle}`)
+  })
+
 // profile: Look up a user
 program
   .command("profile")

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -197,6 +197,24 @@ export async function dispatch(opts: {
       }
     }
 
+    if (action.follow) {
+      const f = action.follow
+      try {
+        const platform = await getPlatformAsync(f.platform)
+        if (!platform.follow) {
+          throw new Error(`Platform ${f.platform} does not support follow`)
+        }
+        const cleanHandle = f.handle.replace(/^@/, "")
+        await platform.follow(cleanHandle)
+        results.push({ action: "follow", platform: f.platform, status: "ok", id: cleanHandle })
+        console.log(`Followed on ${f.platform}: ${cleanHandle}`)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        results.push({ action: "follow", platform: f.platform, status: "error", error: msg })
+        console.error(`Follow failed on ${f.platform}: ${msg}`)
+      }
+    }
+
     if (action.annotate) {
       const a = action.annotate
       try {

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -25,6 +25,10 @@ export interface OutboxAction {
     text: string
     motivation?: string
   }
+  follow?: {
+    platform: string
+    handle: string
+  }
   ignore?: {
     id: string
     reason: string
@@ -67,12 +71,12 @@ export function validateOutbox(outbox: OutboxFile): ValidationResult {
     const prefix = `Action ${i}`
 
     // Determine action type
-    const types = ["reply", "post", "thread", "annotate", "ignore"].filter(
+    const types = ["reply", "post", "thread", "annotate", "follow", "ignore"].filter(
       (t) => action[t as keyof OutboxAction] !== undefined,
     )
 
     if (types.length === 0) {
-      errors.push(`${prefix}: No recognized action type (reply, post, thread, annotate, ignore)`)
+      errors.push(`${prefix}: No recognized action type (reply, post, thread, annotate, follow, ignore)`)
       continue
     }
     if (types.length > 1) {
@@ -145,6 +149,12 @@ export function validateOutbox(outbox: OutboxFile): ValidationResult {
       if (a.platform && a.platform !== "bsky") {
         warnings.push(`${prefix}: annotations only supported on bsky`)
       }
+    }
+
+    if (type === "follow") {
+      const f = action.follow!
+      if (!f.platform) errors.push(`${prefix}: follow missing 'platform'`)
+      if (!f.handle) errors.push(`${prefix}: follow missing 'handle'`)
     }
 
     if (type === "ignore") {

--- a/src/platforms/bluesky.ts
+++ b/src/platforms/bluesky.ts
@@ -351,6 +351,14 @@ export const bluesky: SocialPlatform = {
     })
   },
 
+  async follow(handle: string): Promise<void> {
+    return withSession(async (agent) => {
+      const cleanHandle = handle.replace(/^@/, "")
+      const res = await agent.resolveHandle({ handle: cleanHandle })
+      await agent.follow(res.data.did)
+    })
+  },
+
   async profile(handle: string): Promise<ProfileInfo> {
     return withSession(async (agent) => {
       const profile = await agent.app.bsky.actor.getProfile({ actor: handle })

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -110,6 +110,8 @@ export interface SocialPlatform {
   userPosts?(handle: string, limit?: number): Promise<FeedItem[]>
   /** Attach an annotation to a URL/post. Bluesky-specific. */
   annotate?(targetId: string, text: string, opts?: AnnotateOpts): Promise<PostResult>
+  /** Follow a user by handle or DID. */
+  follow?(handle: string): Promise<void>
 }
 
 /** Per-platform character limits. */


### PR DESCRIPTION
## Summary
- Adds `social-cli follow <handle>` CLI command for Bluesky
- Adds `follow` as an outbox action type for dispatch workflows
- Resolves handle → DID via ATProto, then calls `agent.follow(did)`

Closes #5

🐾 Generated with [Letta Code](https://letta.com)