### PR TITLE
feat: add like action support to outbox dispatch

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -118,6 +118,11 @@ dispatch:
       motivation: commenting
       quote: "exact text from the page to anchor to"
 
+  # Like a post
+  - like:
+      platform: bsky
+      id: "at://did:plc:xxx/app.bsky.feed.post/abc"
+
   # Skip a notification (removes it from inbox)
   - ignore:
       id: "notif_003"

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ dispatch:
       motivation: commenting
       quote: "exact text to anchor to"
 
+  - like:
+      platform: bsky
+      id: "at://did:plc:xxx/app.bsky.feed.post/abc"
+
   - ignore:
       id: "notif_003"
       reason: "spam"

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -385,6 +385,23 @@ export async function dispatch(opts: {
       }
     }
 
+    if (action.like) {
+      const l = action.like
+      try {
+        const platform = await getPlatformAsync(l.platform)
+        if (!platform.like) {
+          throw new Error(`Platform ${l.platform} does not support like`)
+        }
+        await platform.like(l.id)
+        results.push({ action: "like", platform: l.platform, status: "ok", targetId: l.id })
+        console.log(`Liked on ${l.platform}: ${l.id}`)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        results.push({ action: "like", platform: l.platform, status: "error", targetId: l.id, error: msg })
+        console.error(`Like failed on ${l.platform}: ${msg}`)
+      }
+    }
+
     if (action.annotate) {
       const a = action.annotate
       try {

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -33,6 +33,10 @@ export interface OutboxAction {
     platform: string
     handle: string
   }
+  like?: {
+    platform: string
+    id: string
+  }
   ignore?: {
     id: string
     reason: string
@@ -75,12 +79,12 @@ export function validateOutbox(outbox: OutboxFile): ValidationResult {
     const prefix = `Action ${i}`
 
     // Determine action type
-    const types = ["reply", "post", "thread", "annotate", "follow", "ignore"].filter(
+    const types = ["reply", "post", "thread", "annotate", "follow", "like", "ignore"].filter(
       (t) => action[t as keyof OutboxAction] !== undefined,
     )
 
     if (types.length === 0) {
-      errors.push(`${prefix}: No recognized action type (reply, post, thread, annotate, follow, ignore)`)
+      errors.push(`${prefix}: No recognized action type (reply, post, thread, annotate, follow, like, ignore)`)
       continue
     }
     if (types.length > 1) {
@@ -159,6 +163,12 @@ export function validateOutbox(outbox: OutboxFile): ValidationResult {
       const f = action.follow!
       if (!f.platform) errors.push(`${prefix}: follow missing 'platform'`)
       if (!f.handle) errors.push(`${prefix}: follow missing 'handle'`)
+    }
+
+    if (type === "like") {
+      const l = action.like!
+      if (!l.platform) errors.push(`${prefix}: like missing 'platform'`)
+      if (!l.id) errors.push(`${prefix}: like missing 'id'`)
     }
 
     if (type === "ignore") {


### PR DESCRIPTION
## Summary
- Adds `like` action support to the outbox.yaml dispatch system
- Enables batch liking of posts alongside other actions (reply, post, thread, follow, annotate)
- Works on both Bluesky and X platforms (both already have `platform.like()` implementations)

## Changes
- Added `like` action type to `OutboxAction` interface in `validate.ts`
- Added validation for `like` action (requires `platform` and `id` fields)
- Added dispatch handler for `like` action in `dispatch.ts`
- Updated `README.md` with `like` action example in outbox format
- Updated `AGENT_GUIDE.md` with `like` action example

## Example usage

```yaml
dispatch:
  - like:
      platform: bsky
      id: "at://did:plc:xxx/app.bsky.feed.post/abc"

  - like:
      platform: x
      id: "2036591625644699785"
```

## Test plan
- [x] Build passes (`npm run build`)
- [x] Tests pass (`npm test`)
- [x] TypeScript compilation succeeds with no errors
- [x] Validation logic correctly rejects missing `platform` or `id`
- [x] Dispatch handler follows same pattern as other actions (follow, annotate)

👾 Generated with [Letta Code](https://letta.com)