### PR TITLE
feat: add update-profile command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -292,4 +292,31 @@ program
     process.stdout.write(stringify(info))
   })
 
+// update-profile: Update profile fields
+program
+  .command("update-profile")
+  .description("Update profile (avatar, display name, bio)")
+  .option("-p, --platform <platform>", "Platform", "bsky")
+  .option("--avatar <path>", "Path to avatar image (png/jpg/webp)")
+  .option("--display-name <name>", "Display name")
+  .option("--bio <text>", "Bio / description")
+  .action(async (opts) => {
+    if (!opts.avatar && opts.displayName === undefined && opts.bio === undefined) {
+      console.error("At least one of --avatar, --display-name, or --bio is required")
+      process.exit(1)
+    }
+    const { getPlatformAsync } = await import("./platforms/index.js")
+    const platform = await getPlatformAsync(opts.platform)
+    if (!platform.updateProfile) {
+      console.error(`Platform ${opts.platform} does not support profile updates`)
+      process.exit(1)
+    }
+    await platform.updateProfile({
+      avatar: opts.avatar,
+      displayName: opts.displayName,
+      description: opts.bio,
+    })
+    console.log("Profile updated.")
+  })
+
 program.parse()

--- a/src/platforms/bluesky.ts
+++ b/src/platforms/bluesky.ts
@@ -5,6 +5,8 @@
 
 import { Agent, CredentialSession, RichText, AppBskyFeedPost, ComAtprotoRepoStrongRef } from "@atproto/api"
 import { createHash } from "node:crypto"
+import { readFileSync } from "node:fs"
+import { extname } from "node:path"
 import type {
   SocialPlatform,
   PostOpts,
@@ -372,6 +374,55 @@ export const bluesky: SocialPlatform = {
         followingCount: profile.data.followsCount,
         postsCount: profile.data.postsCount,
       }
+    })
+  },
+
+  async updateProfile(opts: { avatar?: string; displayName?: string; description?: string }): Promise<void> {
+    return withSession(async (agent) => {
+      const did = agent.did
+      if (!did) throw new Error("Cannot determine DID for profile update")
+
+      // Fetch existing profile record so we don't clobber fields
+      let existing: Record<string, any> = {}
+      try {
+        const res = await agent.com.atproto.repo.getRecord({
+          repo: did,
+          collection: "app.bsky.actor.profile",
+          rkey: "self",
+        })
+        existing = (res.data.value as Record<string, any>) ?? {}
+      } catch {
+        // No existing profile record — start fresh
+      }
+
+      const record: Record<string, any> = {
+        $type: "app.bsky.actor.profile",
+        ...existing,
+      }
+
+      if (opts.displayName !== undefined) record.displayName = opts.displayName
+      if (opts.description !== undefined) record.description = opts.description
+
+      if (opts.avatar) {
+        const imageBytes = readFileSync(opts.avatar)
+        const ext = extname(opts.avatar).toLowerCase()
+        const mimeTypes: Record<string, string> = {
+          ".png": "image/png",
+          ".jpg": "image/jpeg",
+          ".jpeg": "image/jpeg",
+          ".webp": "image/webp",
+        }
+        const encoding = mimeTypes[ext] ?? "image/png"
+        const blob = await agent.uploadBlob(imageBytes, { encoding })
+        record.avatar = blob.data.blob
+      }
+
+      await agent.com.atproto.repo.putRecord({
+        repo: did,
+        collection: "app.bsky.actor.profile",
+        rkey: "self",
+        record,
+      })
     })
   },
 }

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -130,6 +130,8 @@ export interface SocialPlatform {
   annotate?(targetId: string, text: string, opts?: AnnotateOpts): Promise<PostResult>
   /** Follow a user by handle or DID. */
   follow?(handle: string): Promise<void>
+  /** Update profile fields (avatar, display name, bio). */
+  updateProfile?(opts: { avatar?: string; displayName?: string; description?: string }): Promise<void>
 }
 
 /** Per-platform character limits. */


### PR DESCRIPTION
## Summary
- Adds `update-profile` command with `--avatar`, `--display-name`, and `--bio` flags
- Bluesky implementation: fetches existing profile record, merges fields, uploads avatar blobs via `putRecord`
- Interface addition: optional `updateProfile` on `SocialPlatform`

🐾 Generated with [Letta Code](https://letta.com)