### PR TITLE
feat: add --feed flag for custom feed generator URIs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,16 +77,18 @@ program
 // feed: Read timeline
 program
   .command("feed")
-  .description("Fetch timeline → feed.yaml")
+  .description("Fetch timeline or custom feed → feed.yaml")
   .option("-p, --platform <platform>", "Platform", "bsky")
   .option("-n, --limit <number>", "Max posts", "50")
   .option("-o, --output <file>", "Output file", "feed.yaml")
+  .option("--feed <uri>", "Feed generator AT-URI (e.g. at://did:plc:.../app.bsky.feed.generator/my-feed)")
   .action(async (opts) => {
     const { feed } = await import("./commands/feed.js")
     await feed({
       platform: opts.platform,
       limit: parseInt(opts.limit),
       output: opts.output,
+      feed: opts.feed,
     })
   })
 

--- a/src/commands/feed.ts
+++ b/src/commands/feed.ts
@@ -11,9 +11,10 @@ export async function feed(opts: {
   platform?: string
   limit?: number
   output?: string
+  feed?: string
 }): Promise<void> {
   const platform = await getPlatformAsync(opts.platform ?? "bsky")
-  const items = await platform.feed(opts.limit ?? 50)
+  const items = await platform.feed(opts.limit ?? 50, opts.feed)
   const output = opts.output ?? "feed.yaml"
   const content = stringify(items, { lineWidth: 120 })
 

--- a/src/platforms/bluesky.ts
+++ b/src/platforms/bluesky.ts
@@ -228,9 +228,11 @@ export const bluesky: SocialPlatform = {
     })
   },
 
-  async feed(limit = 50): Promise<FeedItem[]> {
+  async feed(limit = 50, feedUri?: string): Promise<FeedItem[]> {
     return withSession(async (agent) => {
-      const res = await agent.getTimeline({ limit })
+      const res = feedUri
+        ? await agent.app.bsky.feed.getFeed({ feed: feedUri, limit })
+        : await agent.getTimeline({ limit })
       return res.data.feed.map((item) => ({
         platform: "bsky",
         id: item.post.uri,

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -113,7 +113,7 @@ export interface SocialPlatform {
   thread(posts: string[]): Promise<PostResult[]>
   notifications(opts?: NotifOpts): Promise<NotifResult>
   search(query: string, limit?: number): Promise<SearchResult[]>
-  feed(limit?: number): Promise<FeedItem[]>
+  feed(limit?: number, feedUri?: string): Promise<FeedItem[]>
   rateLimitStatus(): Promise<RateLimitInfo>
 
   /** Delete a post by ID/URI. */


### PR DESCRIPTION
## Summary
- Adds `--feed <at-uri>` option to the `feed` command
- When provided, uses `app.bsky.feed.getFeed` instead of `getTimeline`
- Passes through the `feedUri` parameter via the `SocialPlatform.feed()` interface

Tested against `at://did:plc:gfrmhdmjvxn2sjedzboeudef/app.bsky.feed.generator/atproto-ai`.

🐾 Generated with [Letta Code](https://letta.com)