### PR TITLE
docs: add blog command to README and create blog skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ social-cli posts alice.bsky.social -n 10     # → stdout YAML
 social-cli profile alice.bsky.social         # → stdout YAML
 social-cli rate-limits                       # → stdout YAML
 social-cli whoami                            # → stdout YAML (all platforms)
+social-cli blog --file post.md               # publish to GreenGale
 ```
 
 ### Profile management
@@ -131,6 +132,39 @@ dispatch:
       id: "notif_003"
       reason: "spam"
 ```
+
+## Blog publishing
+
+Publish long-form content to GreenGale (`app.greengale.document`):
+
+```bash
+# From file (supports frontmatter)
+social-cli blog --file my-post.md
+
+# With options
+social-cli blog --file my-post.md --title "Custom Title" --slug "custom-slug"
+
+# Inline content
+social-cli blog --title "Quick Note" --content "Markdown content here"
+```
+
+Options:
+- `--file` — Path to markdown file
+- `--title` — Override title (or use frontmatter `title:`)
+- `--slug` — Override slug (defaults to filename without date prefix)
+- `--subtitle` — Optional subtitle
+
+Frontmatter is stripped automatically:
+
+```markdown
+---
+title: My Post
+slug: my-post
+---
+# Actual content starts here
+```
+
+Published posts appear at: `https://greengale.app/{handle}/{slug}`
 
 ## Annotations
 

--- a/skills/blog/SKILL.md
+++ b/skills/blog/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: blog
+description: Publish long-form markdown content to GreenGale (ATProtocol-native blogging). Use when asked to publish a blog post, write an article, or post long-form content.
+version: 0.1.0
+license: MIT
+---
+
+# Blog Publishing Skill
+
+Publish markdown posts to GreenGale via ATProtocol (`app.greengale.document`).
+
+## When to Use
+
+- User wants to publish a blog post
+- Long-form content needs to go to GreenGale
+- Creating documentation or articles
+
+## Commands
+
+```bash
+# From file (recommended)
+node dist/cli.js blog --file path/to/post.md
+
+# With overrides
+node dist/cli.js blog --file post.md --title "Custom Title" --slug "custom-slug"
+
+# Inline content
+node dist/cli.js blog --title "Quick Note" --content "Markdown here"
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--file` | Path to markdown file |
+| `--title` | Post title (or from frontmatter) |
+| `--slug` | URL slug (defaults to filename) |
+| `--subtitle` | Optional subtitle |
+
+## Frontmatter Support
+
+Posts can include YAML frontmatter:
+
+```markdown
+---
+title: My Post Title
+slug: my-post-slug
+---
+# Content starts here
+
+Your markdown content...
+```
+
+Frontmatter is automatically stripped before publishing.
+
+## Output
+
+Returns on success:
+- `Published: https://greengale.app/{handle}/{slug}`
+- `URI: at://did:plc:.../app.greengale.document/{slug}`
+- `CID: bafyrei...`
+
+## Requirements
+
+Set in `.env`:
+- `ATPROTO_HANDLE` — Your ATProto handle
+- `ATPROTO_APP_PASSWORD` — App password
+- `ATPROTO_PDS` — Your PDS URL (optional, defaults to bsky.social)
+
+## Notes
+
+- GreenGale indexes from the firehose — no separate publish step needed
+- Posts use `github-dark` theme by default
+- Records are written directly to your PDS via XRPC


### PR DESCRIPTION
## Summary

- Add `blog` command documentation to README with examples
- Create `skills/blog/SKILL.md` documenting blog publishing workflow
- Document frontmatter support, options, and GreenGale integration

## Test plan

- [ ] Verify blog command exists: `node dist/cli.js blog --help`
- [ ] Run `social-cli blog --file test.md` with a test post

👾 Generated with [Letta Code](https://letta.com)