### PR TITLE
feat: post-action hook system for dispatch pipeline

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -172,6 +172,29 @@ social-cli dispatch --dry-run
 
 Always dry-run if you're unsure about your outbox.
 
+### Dispatch hooks
+
+Operators can configure hooks in `config.yaml` to run scripts around dispatch actions:
+
+```yaml
+hooks:
+  preDispatch:
+    - event: reply
+      command: "bash hooks/example-validate-reply.sh"
+  postDispatch:
+    - event: "*"
+      command: "bash hooks/example-log-dispatch.sh"
+  onError:
+    - event: "*"
+      command: "bash hooks/example-log-dispatch.sh"
+```
+
+Hooks only apply to the dispatch pipeline, not quick commands. Events are `reply`, `post`, `thread`, `follow`, `like`, `annotate`, `bookmark`, `highlight`, or `*`.
+
+`preDispatch` hooks are blocking: exit `0` allows the action, exit `1` skips it, exit `2` aborts dispatch. `postDispatch` and `onError` hooks are async follow-ups.
+
+Hook scripts receive context as environment variables: `SOCIAL_HOOK_EVENT`, `SOCIAL_HOOK_PLATFORM`, `SOCIAL_HOOK_ACTION_ID`, `SOCIAL_HOOK_TARGET_ID`, `SOCIAL_HOOK_TEXT`, `SOCIAL_HOOK_OUTBOX_PATH`, `SOCIAL_HOOK_RESULT`, and `SOCIAL_HOOK_ERROR`.
+
 ## Quick Commands
 
 For one-off actions outside the sync/dispatch loop:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ X_BEARER_TOKEN=...                      # optional, for app-only endpoints
 
 You only need the credentials for the platforms you use.
 
+Optional configuration lives in `config.yaml` in the working directory (or `~/.config/social-cli/config.yaml`). This is where dispatch hooks are configured.
+
 ## Commands
 
 ### Agent loop
@@ -140,6 +142,56 @@ dispatch:
       id: "notif_003"
       reason: "spam"
 ```
+
+## Dispatch hooks
+
+Hooks let you run scripts before or after `dispatch` actions. They are configured in `config.yaml` and currently apply to the **dispatch pipeline** — not quick commands like `post` or `reply`.
+
+```yaml
+hooks:
+  preDispatch:
+    - event: reply
+      command: "bash hooks/example-validate-reply.sh"
+
+  postDispatch:
+    - event: thread
+      command: "bash hooks/example-log-dispatch.sh"
+    - event: "*"
+      command: "bash hooks/example-log-dispatch.sh"
+
+  onError:
+    - event: "*"
+      command: "bash hooks/example-log-dispatch.sh"
+```
+
+### Lifecycles
+
+- `preDispatch` — synchronous, blocking. Runs once per action before dispatch.
+  - exit `0`: allow action
+  - exit `1`: skip action
+  - exit `2`: abort remaining dispatch work
+- `postDispatch` — async, fire-and-forget. Runs after a successful action.
+- `onError` — async, fire-and-forget. Runs after a failed action.
+
+Hooks match the action `event` (`reply`, `post`, `thread`, `follow`, `like`, `annotate`, `bookmark`, `highlight`) or wildcard `"*"`.
+
+### Environment variables
+
+Each hook receives context through environment variables:
+
+- `SOCIAL_HOOK_EVENT`
+- `SOCIAL_HOOK_PLATFORM`
+- `SOCIAL_HOOK_ACTION_ID`
+- `SOCIAL_HOOK_TARGET_ID`
+- `SOCIAL_HOOK_TEXT`
+- `SOCIAL_HOOK_OUTBOX_PATH`
+- `SOCIAL_HOOK_RESULT`
+- `SOCIAL_HOOK_ERROR` (only on failures)
+
+The repo includes example scripts in `hooks/`:
+
+- `hooks/example-validate-reply.sh`
+- `hooks/example-log-dispatch.sh`
 
 ## Blog publishing
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ For Leaflet publishing, either pass `--publication <at-uri>` on each publish or 
 LEAFLET_PUBLICATION_URI=at://did:plc:.../site.standard.publication/...
 ```
 
+Optional dispatch hooks are also configured in `config.yaml`; see [Dispatch hooks](#dispatch-hooks).
+
 ## How it works
 
 social-cli has two modes: an **agent loop** for automated notification handling, and **quick commands** for direct actions.
@@ -143,6 +145,56 @@ dispatch:
       motivation: commenting
       quote: "exact text to anchor to"
 ```
+
+## Dispatch hooks
+
+Hooks let you run scripts before or after `dispatch` actions. They are configured in `config.yaml` and currently apply to the **dispatch pipeline** — not quick commands like `post` or `reply`.
+
+```yaml
+hooks:
+  preDispatch:
+    - event: reply
+      command: "bash hooks/example-validate-reply.sh"
+
+  postDispatch:
+    - event: thread
+      command: "bash hooks/example-log-dispatch.sh"
+    - event: "*"
+      command: "bash hooks/example-log-dispatch.sh"
+
+  onError:
+    - event: "*"
+      command: "bash hooks/example-log-dispatch.sh"
+```
+
+### Lifecycles
+
+- `preDispatch` — synchronous, blocking. Runs once per action before dispatch.
+  - exit `0`: allow action
+  - exit `1`: skip action
+  - exit `2`: abort remaining dispatch work
+- `postDispatch` — async, fire-and-forget. Runs after a successful action.
+- `onError` — async, fire-and-forget. Runs after a failed action.
+
+Hooks match the action `event` (`reply`, `post`, `thread`, `follow`, `like`, `annotate`, `bookmark`, `highlight`) or wildcard `"*"`.
+
+### Environment variables
+
+Each hook receives context through environment variables:
+
+- `SOCIAL_HOOK_EVENT`
+- `SOCIAL_HOOK_PLATFORM`
+- `SOCIAL_HOOK_ACTION_ID`
+- `SOCIAL_HOOK_TARGET_ID`
+- `SOCIAL_HOOK_TEXT`
+- `SOCIAL_HOOK_OUTBOX_PATH`
+- `SOCIAL_HOOK_RESULT`
+- `SOCIAL_HOOK_ERROR` (only on failures)
+
+The repo includes example scripts in `hooks/`:
+
+- `hooks/example-validate-reply.sh`
+- `hooks/example-log-dispatch.sh`
 
 ## Platforms
 

--- a/hooks/example-log-dispatch.sh
+++ b/hooks/example-log-dispatch.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Example post-dispatch hook: log all dispatched actions
+#
+# Appends a line to a dispatch log file. Fire-and-forget — errors
+# are logged but don't affect dispatch.
+#
+# Install: copy to hooks/ and add to config.yaml:
+#   hooks:
+#     postDispatch:
+#       - event: "*"
+#         command: "bash hooks/example-log-dispatch.sh"
+
+set -euo pipefail
+
+LOG_FILE="${SOCIAL_HOOK_LOG_FILE:-/tmp/social-cli-dispatch.log}"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+echo "${TIMESTAMP} event=${SOCIAL_HOOK_EVENT} platform=${SOCIAL_HOOK_PLATFORM} action_id=${SOCIAL_HOOK_ACTION_ID} target_id=${SOCIAL_HOOK_TARGET_ID}" >> "$LOG_FILE"

--- a/hooks/example-validate-reply.sh
+++ b/hooks/example-validate-reply.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Example pre-dispatch hook: validate reply content
+#
+# Blocks replies that are too short (likely low-effort) or contain
+# certain patterns. Exit 0 = pass, 1 = block, 2 = abort.
+#
+# Install: copy to hooks/ and add to config.yaml:
+#   hooks:
+#     preDispatch:
+#       - event: reply
+#         command: "bash hooks/example-validate-reply.sh"
+
+set -euo pipefail
+
+TEXT="${SOCIAL_HOOK_TEXT:-}"
+TARGET="${SOCIAL_HOOK_TARGET_ID:-}"
+PLATFORM="${SOCIAL_HOOK_PLATFORM:-}"
+
+# Block empty or very short replies (under 10 chars)
+if [ ${#TEXT} -lt 10 ]; then
+  echo "Reply too short (${#TEXT} chars): minimum 10"
+  exit 1
+fi
+
+# Block replies that are just emoji
+if [[ "$TEXT" =~ ^[[:space:][:emoji:]]+$ ]]; then
+  echo "Reply is only emoji/spaces"
+  exit 1
+fi
+
+# Pass
+exit 0

--- a/src/commands/dispatch.test.ts
+++ b/src/commands/dispatch.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { stringify } from "yaml"
+import type { SocialPlatform } from "../platforms/types.js"
+
+const { runHooksMock, getPlatformAsyncMock } = vi.hoisted(() => ({
+  runHooksMock: vi.fn(),
+  getPlatformAsyncMock: vi.fn(),
+}))
+
+vi.mock("../hooks.js", () => ({
+  runHooks: runHooksMock,
+}))
+
+vi.mock("../platforms/index.js", () => ({
+  getPlatformAsync: getPlatformAsyncMock,
+}))
+
+import { dispatch } from "./dispatch.js"
+
+function createPlatform(overrides: Partial<SocialPlatform> = {}): SocialPlatform {
+  return {
+    name: "test",
+    post: async () => {
+      throw new Error("post not implemented")
+    },
+    reply: async () => {
+      throw new Error("reply not implemented")
+    },
+    thread: async () => {
+      throw new Error("thread not implemented")
+    },
+    notifications: async () => ({ notifications: [] }),
+    search: async () => [],
+    feed: async () => [],
+    rateLimitStatus: async () => ({
+      platform: "test",
+      remaining: 0,
+      limit: 0,
+      resetsAt: new Date(0).toISOString(),
+    }),
+    ...overrides,
+  }
+}
+
+describe("dispatch hook alignment", () => {
+  const originalCwd = process.cwd()
+  let testDir: string
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "social-cli-dispatch-test-"))
+    process.chdir(testDir)
+    writeFileSync(join(testDir, "config.yaml"), stringify({ accounts: {} }))
+
+    runHooksMock.mockReset()
+    runHooksMock.mockResolvedValue({ results: [], blocked: false, abort: false })
+    getPlatformAsyncMock.mockReset()
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it("fires postDispatch hooks with the correct action for multi-platform posts", async () => {
+    getPlatformAsyncMock.mockImplementation(async (platform: string) => {
+      if (platform === "bsky") {
+        return createPlatform({
+          post: async (text: string) => ({ platform: "bsky", id: "bsky-post-1", uri: "at://bsky-post-1", text }),
+          follow: async () => {},
+        })
+      }
+
+      if (platform === "x") {
+        return createPlatform({
+          post: async (text: string) => ({ platform: "x", id: "x-post-1", text }),
+        })
+      }
+
+      throw new Error(`Unexpected platform: ${platform}`)
+    })
+
+    writeFileSync(
+      join(testDir, "outbox-bsky.yaml"),
+      stringify({
+        dispatch: [
+          { post: { text: "Hello from social-cli", platforms: ["bsky", "x"] } },
+          { follow: { platform: "bsky", handle: "alice.bsky.social" } },
+        ],
+      }),
+    )
+
+    await dispatch({ file: "outbox-bsky.yaml" })
+
+    const postDispatchContexts = runHooksMock.mock.calls
+      .filter(([, lifecycle]) => lifecycle === "postDispatch")
+      .map(([, , ctx]) => ({
+        event: ctx.event,
+        platform: ctx.platform,
+        actionId: ctx.actionId,
+        targetId: ctx.targetId,
+        text: ctx.text,
+        result: ctx.result,
+      }))
+
+    expect(postDispatchContexts).toEqual([
+      {
+        event: "post",
+        platform: "bsky",
+        actionId: "bsky-post-1",
+        targetId: undefined,
+        text: "Hello from social-cli",
+        result: "success",
+      },
+      {
+        event: "post",
+        platform: "x",
+        actionId: "x-post-1",
+        targetId: undefined,
+        text: "Hello from social-cli",
+        result: "success",
+      },
+      {
+        event: "follow",
+        platform: "bsky",
+        actionId: "alice.bsky.social",
+        targetId: undefined,
+        text: "",
+        result: "success",
+      },
+    ])
+  })
+
+  it("fires one thread hook and keeps the next action aligned", async () => {
+    const bsky = createPlatform({
+      thread: async (posts: string[]) => posts.map((text, idx) => ({
+        platform: "bsky",
+        id: `thread-${idx + 1}`,
+        uri: `at://thread-${idx + 1}`,
+        text,
+      })),
+      like: async () => {},
+    })
+
+    getPlatformAsyncMock.mockResolvedValue(bsky)
+
+    writeFileSync(
+      join(testDir, "outbox-bsky.yaml"),
+      stringify({
+        dispatch: [
+          { thread: { platform: "bsky", posts: ["First", "Second"] } },
+          { like: { platform: "bsky", id: "at://target-post" } },
+        ],
+      }),
+    )
+
+    await dispatch({ file: "outbox-bsky.yaml" })
+
+    const postDispatchContexts = runHooksMock.mock.calls
+      .filter(([, lifecycle]) => lifecycle === "postDispatch")
+      .map(([, , ctx]) => ({
+        event: ctx.event,
+        platform: ctx.platform,
+        actionId: ctx.actionId,
+        targetId: ctx.targetId,
+        text: ctx.text,
+        result: ctx.result,
+      }))
+
+    expect(postDispatchContexts).toEqual([
+      {
+        event: "thread",
+        platform: "bsky",
+        actionId: "thread-1",
+        targetId: undefined,
+        text: "First\nSecond",
+        result: "success",
+      },
+      {
+        event: "like",
+        platform: "bsky",
+        actionId: undefined,
+        targetId: "at://target-post",
+        text: "",
+        result: "success",
+      },
+    ])
+  })
+
+  it("fires onError hooks with the correct target platform for per-platform post failures", async () => {
+    getPlatformAsyncMock.mockImplementation(async (platform: string) => {
+      if (platform === "bsky") {
+        return createPlatform({
+          post: async (text: string) => ({ platform: "bsky", id: "bsky-post-1", uri: "at://bsky-post-1", text }),
+        })
+      }
+
+      if (platform === "x") {
+        return createPlatform({
+          post: async () => {
+            throw new Error("x post failed")
+          },
+        })
+      }
+
+      throw new Error(`Unexpected platform: ${platform}`)
+    })
+
+    writeFileSync(
+      join(testDir, "outbox-bsky.yaml"),
+      stringify({
+        dispatch: [
+          { post: { text: "Hello from social-cli", platforms: ["bsky", "x"] } },
+        ],
+      }),
+    )
+
+    await expect(dispatch({ file: "outbox-bsky.yaml" })).rejects.toThrow('process.exit unexpectedly called with "2"')
+
+    const postDispatchContexts = runHooksMock.mock.calls
+      .filter(([, lifecycle]) => lifecycle === "postDispatch")
+      .map(([, , ctx]) => ({
+        event: ctx.event,
+        platform: ctx.platform,
+        actionId: ctx.actionId,
+        text: ctx.text,
+        result: ctx.result,
+      }))
+
+    const errorContexts = runHooksMock.mock.calls
+      .filter(([, lifecycle]) => lifecycle === "onError")
+      .map(([, , ctx]) => ({
+        event: ctx.event,
+        platform: ctx.platform,
+        actionId: ctx.actionId,
+        targetId: ctx.targetId,
+        text: ctx.text,
+        result: ctx.result,
+        error: ctx.error,
+      }))
+
+    expect(postDispatchContexts).toEqual([
+      {
+        event: "post",
+        platform: "bsky",
+        actionId: "bsky-post-1",
+        text: "Hello from social-cli",
+        result: "success",
+      },
+    ])
+
+    expect(errorContexts).toEqual([
+      {
+        event: "post",
+        platform: "x",
+        actionId: undefined,
+        targetId: undefined,
+        text: "Hello from social-cli",
+        result: "error",
+        error: "x post failed",
+      },
+    ])
+  })
+})

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -21,6 +21,8 @@ import type { PostOpts } from "../platforms/types.js"
 import { loadConfig } from "../config.js"
 import { validateOutbox, type OutboxFile, type OutboxAction } from "./validate.js"
 import { writeFileAtomic } from "../util/fs.js"
+import { runHooks } from "../hooks.js"
+import type { HookContext } from "../types/hooks.js"
 import {
   getPlatformFilePath,
   getSharedFilePath,
@@ -143,6 +145,41 @@ function buildProvenanceInfo(opts: {
     dispatchTimestamp: new Date().toISOString(),
     dryRun: opts.dryRun,
     platform: opts.platform,
+  }
+}
+
+/**
+ * Build hook context from an outbox action and optional result.
+ */
+function buildHookContext(
+  action: OutboxAction,
+  platform: string,
+  outboxPath: string,
+  opts?: { actionId?: string; result?: "success" | "error"; error?: string; text?: string },
+): HookContext {
+  let event = "post"
+  let text = opts?.text ?? ""
+  let targetId: string | undefined
+
+  if (action.reply) { event = "reply"; text = action.reply.text; targetId = action.reply.id }
+  else if (action.thread) { event = "thread"; text = action.thread.posts.join("\n") }
+  else if (action.post) { event = "post"; text = action.post.text ?? "" }
+  else if (action.follow) { event = "follow" }
+  else if (action.like) { event = "like"; targetId = action.like.id }
+  else if (action.annotate) { event = "annotate"; text = action.annotate.text; targetId = action.annotate.id }
+  else if (action.bookmark) { event = "bookmark"; targetId = action.bookmark.id }
+  else if (action.highlight) { event = "highlight"; targetId = action.highlight.id }
+  else if (action.ignore) { event = "ignore" }
+
+  return {
+    event,
+    platform,
+    actionId: opts?.actionId,
+    targetId,
+    text,
+    outboxPath,
+    result: opts?.result ?? "success",
+    error: opts?.error,
   }
 }
 
@@ -413,6 +450,19 @@ async function dispatchPlatform(
       continue
     }
 
+    // Pre-dispatch hooks: synchronous, blocking
+    const preCtx = buildHookContext(action, platform, outboxPath)
+    const preResult = await runHooks(config.hooks, "preDispatch", preCtx)
+    if (preResult.abort) {
+      console.error(`[${platform}] Dispatch aborted by pre-dispatch hook: ${preResult.reason}`)
+      process.exit(2)
+    }
+    if (preResult.blocked) {
+      console.log(`[${platform}] Action blocked by pre-dispatch hook: ${preResult.reason}`)
+      results.push({ action: preCtx.event, platform, status: "error", error: `Blocked by hook: ${preResult.reason}` })
+      continue
+    }
+
     if (action.reply) {
       const r = action.reply
       try {
@@ -673,6 +723,27 @@ async function dispatchPlatform(
         results.push({ action: "highlight", platform: h.platform, status: "error", error: msg })
         console.error(`[${platform}] Highlight failed on ${h.platform}: ${msg}`)
       }
+    }
+  }
+
+  // Post-dispatch and on-error hooks (async, fire-and-forget)
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i]
+    const action = outbox.dispatch[i]
+    if (!action) continue
+
+    if (result.status === "ok") {
+      const postCtx = buildHookContext(action, platform, outboxPath, {
+        actionId: result.id,
+        result: "success",
+      })
+      runHooks(config.hooks, "postDispatch", postCtx)
+    } else {
+      const errCtx = buildHookContext(action, platform, outboxPath, {
+        result: "error",
+        error: result.error,
+      })
+      runHooks(config.hooks, "onError", errCtx)
     }
   }
 

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -169,7 +169,6 @@ function buildHookContext(
   else if (action.annotate) { event = "annotate"; text = action.annotate.text; targetId = action.annotate.id }
   else if (action.bookmark) { event = "bookmark"; targetId = action.bookmark.id }
   else if (action.highlight) { event = "highlight"; targetId = action.highlight.id }
-  else if (action.ignore) { event = "ignore" }
 
   return {
     event,
@@ -455,7 +454,9 @@ async function dispatchPlatform(
     const preResult = await runHooks(config.hooks, "preDispatch", preCtx)
     if (preResult.abort) {
       console.error(`[${platform}] Dispatch aborted by pre-dispatch hook: ${preResult.reason}`)
-      process.exit(2)
+      results.push({ action: preCtx.event, platform, status: "error", error: `Aborted by hook: ${preResult.reason}` })
+      // Abort remaining actions — archive what we have
+      break
     }
     if (preResult.blocked) {
       console.log(`[${platform}] Action blocked by pre-dispatch hook: ${preResult.reason}`)

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -22,7 +22,7 @@ import { loadConfig } from "../config.js"
 import { validateOutbox, type OutboxFile, type OutboxAction } from "./validate.js"
 import { writeFileAtomic } from "../util/fs.js"
 import { runHooks } from "../hooks.js"
-import type { HookContext } from "../types/hooks.js"
+import type { HookContext, HooksConfig } from "../types/hooks.js"
 import {
   getPlatformFilePath,
   getSharedFilePath,
@@ -155,24 +155,32 @@ function buildHookContext(
   action: OutboxAction,
   platform: string,
   outboxPath: string,
-  opts?: { actionId?: string; result?: "success" | "error"; error?: string; text?: string },
+  opts?: {
+    actionId?: string
+    result?: "success" | "error"
+    error?: string
+    text?: string
+    targetId?: string
+    platform?: string
+  },
 ): HookContext {
   let event = "post"
   let text = opts?.text ?? ""
-  let targetId: string | undefined
+  let targetId = opts?.targetId
+  const hookPlatform = opts?.platform ?? platform
 
-  if (action.reply) { event = "reply"; text = action.reply.text; targetId = action.reply.id }
-  else if (action.thread) { event = "thread"; text = action.thread.posts.join("\n") }
-  else if (action.post) { event = "post"; text = action.post.text ?? "" }
+  if (action.reply) { event = "reply"; text = opts?.text ?? action.reply.text; targetId ??= action.reply.id }
+  else if (action.thread) { event = "thread"; text = opts?.text ?? action.thread.posts.join("\n"); targetId ??= action.thread.replyTo }
+  else if (action.post) { event = "post"; text = opts?.text ?? action.post.text ?? ""; targetId ??= action.post.replyTo }
   else if (action.follow) { event = "follow" }
-  else if (action.like) { event = "like"; targetId = action.like.id }
-  else if (action.annotate) { event = "annotate"; text = action.annotate.text; targetId = action.annotate.id }
-  else if (action.bookmark) { event = "bookmark"; targetId = action.bookmark.id }
-  else if (action.highlight) { event = "highlight"; targetId = action.highlight.id }
+  else if (action.like) { event = "like"; targetId ??= action.like.id }
+  else if (action.annotate) { event = "annotate"; text = opts?.text ?? action.annotate.text; targetId ??= action.annotate.id }
+  else if (action.bookmark) { event = "bookmark"; targetId ??= action.bookmark.id }
+  else if (action.highlight) { event = "highlight"; targetId ??= action.highlight.id }
 
   return {
     event,
-    platform,
+    platform: hookPlatform,
     actionId: opts?.actionId,
     targetId,
     text,
@@ -180,6 +188,31 @@ function buildHookContext(
     result: opts?.result ?? "success",
     error: opts?.error,
   }
+}
+
+function triggerAsyncHook(
+  hooks: HooksConfig | undefined,
+  lifecycle: "postDispatch" | "onError",
+  action: OutboxAction,
+  platform: string,
+  outboxPath: string,
+  opts?: {
+    actionId?: string
+    error?: string
+    text?: string
+    targetId?: string
+  },
+): void {
+  const ctx = buildHookContext(action, platform, outboxPath, {
+    actionId: opts?.actionId,
+    result: lifecycle === "postDispatch" ? "success" : "error",
+    error: opts?.error,
+    text: opts?.text,
+    targetId: opts?.targetId,
+    platform,
+  })
+
+  void runHooks(hooks, lifecycle, ctx)
 }
 
 /**
@@ -501,10 +534,20 @@ async function dispatchPlatform(
           if (n.postId) processedNotifIds.push(n.postId)
         }
         console.log(`[${platform}] Replied on ${r.platform}: ${res.id}`)
+        triggerAsyncHook(config.hooks, "postDispatch", action, r.platform, outboxPath, {
+          actionId: res.id,
+          text: r.text,
+          targetId: r.id,
+        })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         results.push({ action: "reply", platform: r.platform, status: "error", targetId: r.id, error: msg })
         console.error(`[${platform}] Reply failed on ${r.platform}: ${msg}`)
+        triggerAsyncHook(config.hooks, "onError", action, r.platform, outboxPath, {
+          error: msg,
+          text: r.text,
+          targetId: r.id,
+        })
       }
     }
 
@@ -561,16 +604,27 @@ async function dispatchPlatform(
             dryRun: provenance.dryRun,
           })
           console.log(`[${platform}] Posted on ${t.platform}: ${res.id}`)
+          triggerAsyncHook(config.hooks, "postDispatch", action, t.platform, outboxPath, {
+            actionId: res.id,
+            text: t.text,
+            targetId: p.replyTo,
+          })
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err)
           results.push({ action: "post", platform: t.platform, status: "error", error: msg })
           console.error(`[${platform}] Post failed on ${t.platform}: ${msg}`)
+          triggerAsyncHook(config.hooks, "onError", action, t.platform, outboxPath, {
+            error: msg,
+            text: t.text,
+            targetId: p.replyTo,
+          })
         }
       }
     }
 
     if (action.thread) {
       const t = action.thread
+      const threadResultStart = results.length
       try {
         // Resolve media: explicit paths + auto-generated card
         let mediaPaths: string[] = t.media ?? []
@@ -616,15 +670,18 @@ async function dispatchPlatform(
           dryRun: provenance.dryRun,
         })
         console.log(`[${platform}] Thread posted on ${t.platform}: ${res.length} posts`)
+        triggerAsyncHook(config.hooks, "postDispatch", action, t.platform, outboxPath, {
+          actionId: res[0]?.id,
+          text: t.posts.join("\n"),
+          targetId: t.replyTo,
+        })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
-        // Find how many posts succeeded before failure
-        const okCount = results.filter(
-          (r) => r.action === "thread" && r.platform === t.platform && r.status === "ok",
-        ).length
-        const lastOk = okCount > 0 ? results.filter(
-          (r) => r.action === "thread" && r.platform === t.platform && r.status === "ok",
-        ).pop() : undefined
+        const currentThreadResults = results
+          .slice(threadResultStart)
+          .filter((r) => r.action === "thread" && r.platform === t.platform && r.status === "ok")
+        const okCount = currentThreadResults.length
+        const lastOk = okCount > 0 ? currentThreadResults.at(-1) : undefined
         results.push({
           action: "thread",
           platform: t.platform,
@@ -637,6 +694,11 @@ async function dispatchPlatform(
           } : undefined,
         } as any)
         console.error(`[${platform}] Thread failed on ${t.platform} at post ${okCount + 1}/${t.posts.length}: ${msg}`)
+        triggerAsyncHook(config.hooks, "onError", action, t.platform, outboxPath, {
+          error: msg,
+          text: t.posts.join("\n"),
+          targetId: t.replyTo,
+        })
       }
     }
 
@@ -651,10 +713,16 @@ async function dispatchPlatform(
         await plat.follow(cleanHandle)
         results.push({ action: "follow", platform: f.platform, status: "ok", id: cleanHandle })
         console.log(`[${platform}] Followed on ${f.platform}: ${cleanHandle}`)
+        triggerAsyncHook(config.hooks, "postDispatch", action, f.platform, outboxPath, {
+          actionId: cleanHandle,
+        })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         results.push({ action: "follow", platform: f.platform, status: "error", error: msg })
         console.error(`[${platform}] Follow failed on ${f.platform}: ${msg}`)
+        triggerAsyncHook(config.hooks, "onError", action, f.platform, outboxPath, {
+          error: msg,
+        })
       }
     }
 
@@ -668,10 +736,17 @@ async function dispatchPlatform(
         await plat.like(l.id)
         results.push({ action: "like", platform: l.platform, status: "ok", targetId: l.id })
         console.log(`[${platform}] Liked on ${l.platform}: ${l.id}`)
+        triggerAsyncHook(config.hooks, "postDispatch", action, l.platform, outboxPath, {
+          targetId: l.id,
+        })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         results.push({ action: "like", platform: l.platform, status: "error", targetId: l.id, error: msg })
         console.error(`[${platform}] Like failed on ${l.platform}: ${msg}`)
+        triggerAsyncHook(config.hooks, "onError", action, l.platform, outboxPath, {
+          error: msg,
+          targetId: l.id,
+        })
       }
     }
 
@@ -685,10 +760,20 @@ async function dispatchPlatform(
         const res = await plat.annotate(a.id, a.text, { motivation: a.motivation })
         results.push({ action: "annotate", platform: a.platform, status: "ok", id: res.id })
         console.log(`[${platform}] Annotated on ${a.platform}: ${res.id}`)
+        triggerAsyncHook(config.hooks, "postDispatch", action, a.platform, outboxPath, {
+          actionId: res.id,
+          text: a.text,
+          targetId: a.id,
+        })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         results.push({ action: "annotate", platform: a.platform, status: "error", error: msg })
         console.error(`[${platform}] Annotate failed on ${a.platform}: ${msg}`)
+        triggerAsyncHook(config.hooks, "onError", action, a.platform, outboxPath, {
+          error: msg,
+          text: a.text,
+          targetId: a.id,
+        })
       }
     }
 
@@ -702,10 +787,20 @@ async function dispatchPlatform(
         const res = await plat.annotate(b.id, b.text ?? "", { motivation: "bookmarking" })
         results.push({ action: "bookmark", platform: b.platform, status: "ok", id: res.id })
         console.log(`[${platform}] Bookmarked on ${b.platform}: ${res.id}`)
+        triggerAsyncHook(config.hooks, "postDispatch", action, b.platform, outboxPath, {
+          actionId: res.id,
+          text: b.text,
+          targetId: b.id,
+        })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         results.push({ action: "bookmark", platform: b.platform, status: "error", error: msg })
         console.error(`[${platform}] Bookmark failed on ${b.platform}: ${msg}`)
+        triggerAsyncHook(config.hooks, "onError", action, b.platform, outboxPath, {
+          error: msg,
+          text: b.text,
+          targetId: b.id,
+        })
       }
     }
 
@@ -719,32 +814,21 @@ async function dispatchPlatform(
         const res = await plat.annotate(h.id, h.text ?? "", { motivation: "highlighting", quote: h.quote })
         results.push({ action: "highlight", platform: h.platform, status: "ok", id: res.id })
         console.log(`[${platform}] Highlighted on ${h.platform}: ${res.id}`)
+        triggerAsyncHook(config.hooks, "postDispatch", action, h.platform, outboxPath, {
+          actionId: res.id,
+          text: h.text,
+          targetId: h.id,
+        })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         results.push({ action: "highlight", platform: h.platform, status: "error", error: msg })
         console.error(`[${platform}] Highlight failed on ${h.platform}: ${msg}`)
+        triggerAsyncHook(config.hooks, "onError", action, h.platform, outboxPath, {
+          error: msg,
+          text: h.text,
+          targetId: h.id,
+        })
       }
-    }
-  }
-
-  // Post-dispatch and on-error hooks (async, fire-and-forget)
-  for (let i = 0; i < results.length; i++) {
-    const result = results[i]
-    const action = outbox.dispatch[i]
-    if (!action) continue
-
-    if (result.status === "ok") {
-      const postCtx = buildHookContext(action, platform, outboxPath, {
-        actionId: result.id,
-        result: "success",
-      })
-      runHooks(config.hooks, "postDispatch", postCtx)
-    } else {
-      const errCtx = buildHookContext(action, platform, outboxPath, {
-        result: "error",
-        error: result.error,
-      })
-      runHooks(config.hooks, "onError", errCtx)
     }
   }
 

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -21,6 +21,8 @@ import type { PostOpts } from "../platforms/types.js"
 import { loadConfig } from "../config.js"
 import { validateOutbox, type OutboxFile, type OutboxAction } from "./validate.js"
 import { writeFileAtomic } from "../util/fs.js"
+import { runHooks } from "../hooks.js"
+import type { HookContext } from "../types/hooks.js"
 import {
   getPlatformFilePath,
   getSharedFilePath,
@@ -143,6 +145,41 @@ function buildProvenanceInfo(opts: {
     dispatchTimestamp: new Date().toISOString(),
     dryRun: opts.dryRun,
     platform: opts.platform,
+  }
+}
+
+/**
+ * Build hook context from an outbox action and optional result.
+ */
+function buildHookContext(
+  action: OutboxAction,
+  platform: string,
+  outboxPath: string,
+  opts?: { actionId?: string; result?: "success" | "error"; error?: string; text?: string },
+): HookContext {
+  let event = "post"
+  let text = opts?.text ?? ""
+  let targetId: string | undefined
+
+  if (action.reply) { event = "reply"; text = action.reply.text; targetId = action.reply.id }
+  else if (action.thread) { event = "thread"; text = action.thread.posts.join("\n") }
+  else if (action.post) { event = "post"; text = action.post.text ?? "" }
+  else if (action.follow) { event = "follow" }
+  else if (action.like) { event = "like"; targetId = action.like.id }
+  else if (action.annotate) { event = "annotate"; text = action.annotate.text; targetId = action.annotate.id }
+  else if (action.bookmark) { event = "bookmark"; targetId = action.bookmark.id }
+  else if (action.highlight) { event = "highlight"; targetId = action.highlight.id }
+  else if (action.ignore) { event = "ignore" }
+
+  return {
+    event,
+    platform,
+    actionId: opts?.actionId,
+    targetId,
+    text,
+    outboxPath,
+    result: opts?.result ?? "success",
+    error: opts?.error,
   }
 }
 
@@ -413,6 +450,19 @@ async function dispatchPlatform(
       continue
     }
 
+    // Pre-dispatch hooks: synchronous, blocking
+    const preCtx = buildHookContext(action, platform, outboxPath)
+    const preResult = await runHooks(config.hooks, "preDispatch", preCtx)
+    if (preResult.abort) {
+      console.error(`[${platform}] Dispatch aborted by pre-dispatch hook: ${preResult.reason}`)
+      process.exit(2)
+    }
+    if (preResult.blocked) {
+      console.log(`[${platform}] Action blocked by pre-dispatch hook: ${preResult.reason}`)
+      results.push({ action: preCtx.event, platform, status: "error", error: `Blocked by hook: ${preResult.reason}` })
+      continue
+    }
+
     if (action.reply) {
       const r = action.reply
       try {
@@ -656,6 +706,27 @@ async function dispatchPlatform(
         results.push({ action: "highlight", platform: h.platform, status: "error", error: msg })
         console.error(`[${platform}] Highlight failed on ${h.platform}: ${msg}`)
       }
+    }
+  }
+
+  // Post-dispatch and on-error hooks (async, fire-and-forget)
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i]
+    const action = outbox.dispatch[i]
+    if (!action) continue
+
+    if (result.status === "ok") {
+      const postCtx = buildHookContext(action, platform, outboxPath, {
+        actionId: result.id,
+        result: "success",
+      })
+      runHooks(config.hooks, "postDispatch", postCtx)
+    } else {
+      const errCtx = buildHookContext(action, platform, outboxPath, {
+        result: "error",
+        error: result.error,
+      })
+      runHooks(config.hooks, "onError", errCtx)
     }
   }
 

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -22,7 +22,7 @@ import { loadConfig } from "../config.js"
 import { validateOutbox, type OutboxFile, type OutboxAction } from "./validate.js"
 import { writeFileAtomic } from "../util/fs.js"
 import { runHooks } from "../hooks.js"
-import type { HookContext } from "../types/hooks.js"
+import type { HookContext, HooksConfig } from "../types/hooks.js"
 import {
   getPlatformFilePath,
   getSharedFilePath,
@@ -155,24 +155,32 @@ function buildHookContext(
   action: OutboxAction,
   platform: string,
   outboxPath: string,
-  opts?: { actionId?: string; result?: "success" | "error"; error?: string; text?: string },
+  opts?: {
+    actionId?: string
+    result?: "success" | "error"
+    error?: string
+    text?: string
+    targetId?: string
+    platform?: string
+  },
 ): HookContext {
   let event = "post"
   let text = opts?.text ?? ""
-  let targetId: string | undefined
+  let targetId = opts?.targetId
+  const hookPlatform = opts?.platform ?? platform
 
-  if (action.reply) { event = "reply"; text = action.reply.text; targetId = action.reply.id }
-  else if (action.thread) { event = "thread"; text = action.thread.posts.join("\n") }
-  else if (action.post) { event = "post"; text = action.post.text ?? "" }
+  if (action.reply) { event = "reply"; text = opts?.text ?? action.reply.text; targetId ??= action.reply.id }
+  else if (action.thread) { event = "thread"; text = opts?.text ?? action.thread.posts.join("\n"); targetId ??= action.thread.replyTo }
+  else if (action.post) { event = "post"; text = opts?.text ?? action.post.text ?? ""; targetId ??= action.post.replyTo }
   else if (action.follow) { event = "follow" }
-  else if (action.like) { event = "like"; targetId = action.like.id }
-  else if (action.annotate) { event = "annotate"; text = action.annotate.text; targetId = action.annotate.id }
-  else if (action.bookmark) { event = "bookmark"; targetId = action.bookmark.id }
-  else if (action.highlight) { event = "highlight"; targetId = action.highlight.id }
+  else if (action.like) { event = "like"; targetId ??= action.like.id }
+  else if (action.annotate) { event = "annotate"; text = opts?.text ?? action.annotate.text; targetId ??= action.annotate.id }
+  else if (action.bookmark) { event = "bookmark"; targetId ??= action.bookmark.id }
+  else if (action.highlight) { event = "highlight"; targetId ??= action.highlight.id }
 
   return {
     event,
-    platform,
+    platform: hookPlatform,
     actionId: opts?.actionId,
     targetId,
     text,
@@ -180,6 +188,31 @@ function buildHookContext(
     result: opts?.result ?? "success",
     error: opts?.error,
   }
+}
+
+function triggerAsyncHook(
+  hooks: HooksConfig | undefined,
+  lifecycle: "postDispatch" | "onError",
+  action: OutboxAction,
+  platform: string,
+  outboxPath: string,
+  opts?: {
+    actionId?: string
+    error?: string
+    text?: string
+    targetId?: string
+  },
+): void {
+  const ctx = buildHookContext(action, platform, outboxPath, {
+    actionId: opts?.actionId,
+    result: lifecycle === "postDispatch" ? "success" : "error",
+    error: opts?.error,
+    text: opts?.text,
+    targetId: opts?.targetId,
+    platform,
+  })
+
+  void runHooks(hooks, lifecycle, ctx)
 }
 
 /**
@@ -501,10 +534,20 @@ async function dispatchPlatform(
           if (n.postId) processedNotifIds.push(n.postId)
         }
         console.log(`[${platform}] Replied on ${r.platform}: ${res.id}`)
+        triggerAsyncHook(config.hooks, "postDispatch", action, r.platform, outboxPath, {
+          actionId: res.id,
+          text: r.text,
+          targetId: r.id,
+        })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         results.push({ action: "reply", platform: r.platform, status: "error", targetId: r.id, error: msg })
         console.error(`[${platform}] Reply failed on ${r.platform}: ${msg}`)
+        triggerAsyncHook(config.hooks, "onError", action, r.platform, outboxPath, {
+          error: msg,
+          text: r.text,
+          targetId: r.id,
+        })
       }
     }
 
@@ -561,16 +604,27 @@ async function dispatchPlatform(
             dryRun: provenance.dryRun,
           })
           console.log(`[${platform}] Posted on ${t.platform}: ${res.id}`)
+          triggerAsyncHook(config.hooks, "postDispatch", action, t.platform, outboxPath, {
+            actionId: res.id,
+            text: t.text,
+            targetId: p.replyTo,
+          })
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err)
           results.push({ action: "post", platform: t.platform, status: "error", error: msg })
           console.error(`[${platform}] Post failed on ${t.platform}: ${msg}`)
+          triggerAsyncHook(config.hooks, "onError", action, t.platform, outboxPath, {
+            error: msg,
+            text: t.text,
+            targetId: p.replyTo,
+          })
         }
       }
     }
 
     if (action.thread) {
       const t = action.thread
+      const threadResultStart = results.length
       try {
         const mediaPaths: string[] = t.media ?? []
 
@@ -599,15 +653,18 @@ async function dispatchPlatform(
           dryRun: provenance.dryRun,
         })
         console.log(`[${platform}] Thread posted on ${t.platform}: ${res.length} posts`)
+        triggerAsyncHook(config.hooks, "postDispatch", action, t.platform, outboxPath, {
+          actionId: res[0]?.id,
+          text: t.posts.join("\n"),
+          targetId: t.replyTo,
+        })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
-        // Find how many posts succeeded before failure
-        const okCount = results.filter(
-          (r) => r.action === "thread" && r.platform === t.platform && r.status === "ok",
-        ).length
-        const lastOk = okCount > 0 ? results.filter(
-          (r) => r.action === "thread" && r.platform === t.platform && r.status === "ok",
-        ).pop() : undefined
+        const currentThreadResults = results
+          .slice(threadResultStart)
+          .filter((r) => r.action === "thread" && r.platform === t.platform && r.status === "ok")
+        const okCount = currentThreadResults.length
+        const lastOk = okCount > 0 ? currentThreadResults.at(-1) : undefined
         results.push({
           action: "thread",
           platform: t.platform,
@@ -620,6 +677,11 @@ async function dispatchPlatform(
           } : undefined,
         } as any)
         console.error(`[${platform}] Thread failed on ${t.platform} at post ${okCount + 1}/${t.posts.length}: ${msg}`)
+        triggerAsyncHook(config.hooks, "onError", action, t.platform, outboxPath, {
+          error: msg,
+          text: t.posts.join("\n"),
+          targetId: t.replyTo,
+        })
       }
     }
 
@@ -634,10 +696,16 @@ async function dispatchPlatform(
         await plat.follow(cleanHandle)
         results.push({ action: "follow", platform: f.platform, status: "ok", id: cleanHandle })
         console.log(`[${platform}] Followed on ${f.platform}: ${cleanHandle}`)
+        triggerAsyncHook(config.hooks, "postDispatch", action, f.platform, outboxPath, {
+          actionId: cleanHandle,
+        })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         results.push({ action: "follow", platform: f.platform, status: "error", error: msg })
         console.error(`[${platform}] Follow failed on ${f.platform}: ${msg}`)
+        triggerAsyncHook(config.hooks, "onError", action, f.platform, outboxPath, {
+          error: msg,
+        })
       }
     }
 
@@ -651,10 +719,17 @@ async function dispatchPlatform(
         await plat.like(l.id)
         results.push({ action: "like", platform: l.platform, status: "ok", targetId: l.id })
         console.log(`[${platform}] Liked on ${l.platform}: ${l.id}`)
+        triggerAsyncHook(config.hooks, "postDispatch", action, l.platform, outboxPath, {
+          targetId: l.id,
+        })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         results.push({ action: "like", platform: l.platform, status: "error", targetId: l.id, error: msg })
         console.error(`[${platform}] Like failed on ${l.platform}: ${msg}`)
+        triggerAsyncHook(config.hooks, "onError", action, l.platform, outboxPath, {
+          error: msg,
+          targetId: l.id,
+        })
       }
     }
 
@@ -668,10 +743,20 @@ async function dispatchPlatform(
         const res = await plat.annotate(a.id, a.text, { motivation: a.motivation })
         results.push({ action: "annotate", platform: a.platform, status: "ok", id: res.id })
         console.log(`[${platform}] Annotated on ${a.platform}: ${res.id}`)
+        triggerAsyncHook(config.hooks, "postDispatch", action, a.platform, outboxPath, {
+          actionId: res.id,
+          text: a.text,
+          targetId: a.id,
+        })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         results.push({ action: "annotate", platform: a.platform, status: "error", error: msg })
         console.error(`[${platform}] Annotate failed on ${a.platform}: ${msg}`)
+        triggerAsyncHook(config.hooks, "onError", action, a.platform, outboxPath, {
+          error: msg,
+          text: a.text,
+          targetId: a.id,
+        })
       }
     }
 
@@ -685,10 +770,20 @@ async function dispatchPlatform(
         const res = await plat.annotate(b.id, b.text ?? "", { motivation: "bookmarking" })
         results.push({ action: "bookmark", platform: b.platform, status: "ok", id: res.id })
         console.log(`[${platform}] Bookmarked on ${b.platform}: ${res.id}`)
+        triggerAsyncHook(config.hooks, "postDispatch", action, b.platform, outboxPath, {
+          actionId: res.id,
+          text: b.text,
+          targetId: b.id,
+        })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         results.push({ action: "bookmark", platform: b.platform, status: "error", error: msg })
         console.error(`[${platform}] Bookmark failed on ${b.platform}: ${msg}`)
+        triggerAsyncHook(config.hooks, "onError", action, b.platform, outboxPath, {
+          error: msg,
+          text: b.text,
+          targetId: b.id,
+        })
       }
     }
 
@@ -702,32 +797,21 @@ async function dispatchPlatform(
         const res = await plat.annotate(h.id, h.text ?? "", { motivation: "highlighting", quote: h.quote })
         results.push({ action: "highlight", platform: h.platform, status: "ok", id: res.id })
         console.log(`[${platform}] Highlighted on ${h.platform}: ${res.id}`)
+        triggerAsyncHook(config.hooks, "postDispatch", action, h.platform, outboxPath, {
+          actionId: res.id,
+          text: h.text,
+          targetId: h.id,
+        })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         results.push({ action: "highlight", platform: h.platform, status: "error", error: msg })
         console.error(`[${platform}] Highlight failed on ${h.platform}: ${msg}`)
+        triggerAsyncHook(config.hooks, "onError", action, h.platform, outboxPath, {
+          error: msg,
+          text: h.text,
+          targetId: h.id,
+        })
       }
-    }
-  }
-
-  // Post-dispatch and on-error hooks (async, fire-and-forget)
-  for (let i = 0; i < results.length; i++) {
-    const result = results[i]
-    const action = outbox.dispatch[i]
-    if (!action) continue
-
-    if (result.status === "ok") {
-      const postCtx = buildHookContext(action, platform, outboxPath, {
-        actionId: result.id,
-        result: "success",
-      })
-      runHooks(config.hooks, "postDispatch", postCtx)
-    } else {
-      const errCtx = buildHookContext(action, platform, outboxPath, {
-        result: "error",
-        error: result.error,
-      })
-      runHooks(config.hooks, "onError", errCtx)
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ import { readFileSync, existsSync } from "node:fs"
 import { resolve } from "node:path"
 import { parse } from "yaml"
 import { config as loadDotenv } from "dotenv"
+import type { HooksConfig } from "./types/hooks.js"
 
 export interface AccountConfig {
   handle: string
@@ -38,6 +39,7 @@ export interface Config {
   sync?: SyncConfig
   dispatch?: DispatchConfig
   state?: StateConfig
+  hooks?: HooksConfig
 }
 
 interface RawConfig {
@@ -45,6 +47,7 @@ interface RawConfig {
   sync?: SyncConfig
   dispatch?: DispatchConfig
   state?: StateConfig
+  hooks?: HooksConfig
   [key: string]: unknown
 }
 
@@ -70,6 +73,9 @@ export function loadConfig(): Config {
       return {
         accounts,
         sync: parsed.sync,
+        dispatch: parsed.dispatch,
+        state: parsed.state,
+        hooks: parsed.hooks,
       }
     }
   }

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { runHooks } from "./hooks.js"
+
+describe("runHooks", () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "social-cli-hooks-test-"))
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it("passes hook context through environment variables", async () => {
+    const scriptPath = join(tempDir, "print-env.sh")
+    writeFileSync(
+      scriptPath,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'printf "%s|%s|%s|%s" "$SOCIAL_HOOK_EVENT" "$SOCIAL_HOOK_PLATFORM" "$SOCIAL_HOOK_TEXT" "$SOCIAL_HOOK_TARGET_ID"',
+      ].join("\n"),
+    )
+    chmodSync(scriptPath, 0o755)
+
+    const result = await runHooks(
+      {
+        preDispatch: [{ event: "reply", command: `bash ${scriptPath}` }],
+      },
+      "preDispatch",
+      {
+        event: "reply",
+        platform: "x",
+        text: "hello world",
+        targetId: "123",
+        outboxPath: "/tmp/outbox-x.yaml",
+        result: "success",
+      },
+    )
+
+    expect(result.blocked).toBe(false)
+    expect(result.abort).toBe(false)
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0].stdout).toBe("reply|x|hello world|123")
+  })
+
+  it("treats exit code 1 as a block", async () => {
+    const scriptPath = join(tempDir, "block.sh")
+    writeFileSync(
+      scriptPath,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'echo "reply too short"',
+        "exit 1",
+      ].join("\n"),
+    )
+    chmodSync(scriptPath, 0o755)
+
+    const result = await runHooks(
+      {
+        preDispatch: [{ event: "reply", command: `bash ${scriptPath}` }],
+      },
+      "preDispatch",
+      {
+        event: "reply",
+        platform: "bsky",
+        text: "ok",
+        outboxPath: "/tmp/outbox-bsky.yaml",
+        result: "success",
+      },
+    )
+
+    expect(result.blocked).toBe(true)
+    expect(result.abort).toBe(false)
+    expect(result.reason).toBe("reply too short")
+  })
+})

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -5,8 +5,7 @@
  * and returns results with blocking semantics.
  */
 
-import { execFile } from "node:child_process"
-import { resolve } from "node:path"
+import { execFile, type ChildProcess } from "node:child_process"
 import type {
   HookDefinition,
   HookLifecycle,
@@ -56,9 +55,10 @@ function executeHook(
   timeout: number,
 ): Promise<HookResult> {
   return new Promise((resolve) => {
+    let settled = false
     const env = buildEnv(ctx)
 
-    const child = execFile(
+    const child: ChildProcess = execFile(
       "bash",
       ["-c", hook.command],
       {
@@ -68,18 +68,22 @@ function executeHook(
         shell: false,
       },
       (err, stdout, stderr) => {
+        if (settled) return
+        settled = true
         resolve({
           hook,
           timedOut: err?.killed === true && err?.signal === "SIGTERM",
-          exitCode: err ? (err.killed ? null : (typeof err.code === "number" ? err.code : 1)) : 0,
+          exitCode: child.exitCode ?? (err ? 1 : 0),
           stdout: stdout?.trim() ?? "",
           stderr: stderr?.trim() ?? "",
         })
       },
     )
 
-    // Prevent zombie processes
+    // Prevent zombie processes — only resolve if callback hasn't fired
     child.on("error", () => {
+      if (settled) return
+      settled = true
       resolve({
         hook,
         timedOut: false,
@@ -95,7 +99,7 @@ function executeHook(
  * Run all hooks for a given lifecycle point.
  *
  * For preDispatch: runs synchronously, returns blocking result.
- * For postDispatch/onError: runs async, logs errors.
+ * For postDispatch/onError: runs async, logs errors, returns immediately.
  */
 export async function runHooks(
   hooks: HooksConfig | undefined,
@@ -113,16 +117,15 @@ export async function runHooks(
   const matched = hookDefs.filter((h) => matchesEvent(h.event, ctx.event))
   if (matched.length === 0) return empty
 
-  const results: HookResult[] = []
-  let blocked = false
-  let abort = false
-  let reason: string | undefined
+  if (lifecycle === "preDispatch") {
+    // Sync: wait for each result, check blocking
+    const results: HookResult[] = []
+    let blocked = false
+    let abort = false
+    let reason: string | undefined
 
-  for (const hook of matched) {
-    const timeout = hook.timeout ?? DEFAULT_TIMEOUTS[lifecycle]
-
-    if (lifecycle === "preDispatch") {
-      // Sync: wait for result, check blocking
+    for (const hook of matched) {
+      const timeout = hook.timeout ?? DEFAULT_TIMEOUTS[lifecycle]
       const result = await executeHook(hook, ctx, timeout)
       results.push(result)
 
@@ -132,7 +135,7 @@ export async function runHooks(
         blocked = true
         reason = result.stdout || result.stderr || "Hook blocked action"
         console.log(`[hook:${lifecycle}] Action blocked: ${reason}`)
-        break // Don't run further hooks after block
+        break
       } else if (result.exitCode === 2) {
         blocked = true
         abort = true
@@ -140,11 +143,14 @@ export async function runHooks(
         console.error(`[hook:${lifecycle}] Dispatch aborted: ${reason}`)
         break
       }
-      // exit 0 = pass through
-    } else {
-      // Async: fire and forget, but still collect result for logging
+    }
+
+    return { results, blocked, abort, reason }
+  } else {
+    // Async: fire-and-forget, log results
+    for (const hook of matched) {
+      const timeout = hook.timeout ?? DEFAULT_TIMEOUTS[lifecycle]
       executeHook(hook, ctx, timeout).then((result) => {
-        results.push(result)
         if (result.exitCode !== 0 && result.exitCode !== null) {
           console.error(`[hook:${lifecycle}] ${hook.command} failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`)
         } else {
@@ -154,14 +160,7 @@ export async function runHooks(
         // Silently swallow async hook errors
       })
     }
+
+    return { results: [], blocked: false, abort: false }
   }
-
-  return { results, blocked, abort, reason }
-}
-
-/**
- * Load hooks config from the main config object.
- */
-export function getHooksConfig(config: { hooks?: HooksConfig }): HooksConfig {
-  return config.hooks ?? {}
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,167 @@
+/**
+ * Hook runner for social-cli dispatch pipeline.
+ *
+ * Loads hook config, matches events, executes hooks with env vars,
+ * and returns results with blocking semantics.
+ */
+
+import { execFile } from "node:child_process"
+import { resolve } from "node:path"
+import type {
+  HookDefinition,
+  HookLifecycle,
+  HooksConfig,
+  HookContext,
+  HookResult,
+  HookRunResult,
+} from "./types/hooks.js"
+
+const DEFAULT_TIMEOUTS: Record<HookLifecycle, number> = {
+  preDispatch: 30,
+  postDispatch: 60,
+  onError: 60,
+}
+
+/**
+ * Check if a hook's event pattern matches the given action event.
+ */
+function matchesEvent(hookEvent: string, actionEvent: string): boolean {
+  return hookEvent === "*" || hookEvent === actionEvent
+}
+
+/**
+ * Build environment variables from hook context.
+ */
+function buildEnv(ctx: HookContext): Record<string, string> {
+  const env: Record<string, string> = { ...process.env as Record<string, string> }
+
+  env.SOCIAL_HOOK_EVENT = ctx.event
+  env.SOCIAL_HOOK_PLATFORM = ctx.platform
+  env.SOCIAL_HOOK_ACTION_ID = ctx.actionId ?? ""
+  env.SOCIAL_HOOK_TARGET_ID = ctx.targetId ?? ""
+  env.SOCIAL_HOOK_TEXT = ctx.text ?? ""
+  env.SOCIAL_HOOK_OUTBOX_PATH = ctx.outboxPath ?? ""
+  env.SOCIAL_HOOK_RESULT = ctx.result
+  if (ctx.error) env.SOCIAL_HOOK_ERROR = ctx.error
+
+  return env
+}
+
+/**
+ * Execute a single hook command.
+ */
+function executeHook(
+  hook: HookDefinition,
+  ctx: HookContext,
+  timeout: number,
+): Promise<HookResult> {
+  return new Promise((resolve) => {
+    const env = buildEnv(ctx)
+
+    const child = execFile(
+      "bash",
+      ["-c", hook.command],
+      {
+        env,
+        timeout: timeout * 1000,
+        maxBuffer: 1024 * 1024, // 1MB
+        shell: false,
+      },
+      (err, stdout, stderr) => {
+        resolve({
+          hook,
+          timedOut: err?.killed === true && err?.signal === "SIGTERM",
+          exitCode: err ? (err.killed ? null : (typeof err.code === "number" ? err.code : 1)) : 0,
+          stdout: stdout?.trim() ?? "",
+          stderr: stderr?.trim() ?? "",
+        })
+      },
+    )
+
+    // Prevent zombie processes
+    child.on("error", () => {
+      resolve({
+        hook,
+        timedOut: false,
+        exitCode: 1,
+        stdout: "",
+        stderr: "Failed to spawn hook process",
+      })
+    })
+  })
+}
+
+/**
+ * Run all hooks for a given lifecycle point.
+ *
+ * For preDispatch: runs synchronously, returns blocking result.
+ * For postDispatch/onError: runs async, logs errors.
+ */
+export async function runHooks(
+  hooks: HooksConfig | undefined,
+  lifecycle: HookLifecycle,
+  ctx: HookContext,
+): Promise<HookRunResult> {
+  const empty: HookRunResult = { results: [], blocked: false, abort: false }
+
+  if (!hooks) return empty
+
+  const hookDefs = hooks[lifecycle]
+  if (!hookDefs || hookDefs.length === 0) return empty
+
+  // Filter hooks that match this event
+  const matched = hookDefs.filter((h) => matchesEvent(h.event, ctx.event))
+  if (matched.length === 0) return empty
+
+  const results: HookResult[] = []
+  let blocked = false
+  let abort = false
+  let reason: string | undefined
+
+  for (const hook of matched) {
+    const timeout = hook.timeout ?? DEFAULT_TIMEOUTS[lifecycle]
+
+    if (lifecycle === "preDispatch") {
+      // Sync: wait for result, check blocking
+      const result = await executeHook(hook, ctx, timeout)
+      results.push(result)
+
+      console.log(`[hook:${lifecycle}] ${hook.command} → exit ${result.exitCode}${result.timedOut ? " (timed out)" : ""}`)
+
+      if (result.exitCode === 1) {
+        blocked = true
+        reason = result.stdout || result.stderr || "Hook blocked action"
+        console.log(`[hook:${lifecycle}] Action blocked: ${reason}`)
+        break // Don't run further hooks after block
+      } else if (result.exitCode === 2) {
+        blocked = true
+        abort = true
+        reason = result.stdout || result.stderr || "Hook aborted dispatch"
+        console.error(`[hook:${lifecycle}] Dispatch aborted: ${reason}`)
+        break
+      }
+      // exit 0 = pass through
+    } else {
+      // Async: fire and forget, but still collect result for logging
+      executeHook(hook, ctx, timeout).then((result) => {
+        results.push(result)
+        if (result.exitCode !== 0 && result.exitCode !== null) {
+          console.error(`[hook:${lifecycle}] ${hook.command} failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`)
+        } else {
+          console.log(`[hook:${lifecycle}] ${hook.command} → ok`)
+        }
+      }).catch(() => {
+        // Silently swallow async hook errors
+      })
+    }
+  }
+
+  return { results, blocked, abort, reason }
+}
+
+/**
+ * Load hooks config from the main config object.
+ */
+export function getHooksConfig(config: { hooks?: HooksConfig }): HooksConfig {
+  return config.hooks ?? {}
+}

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,0 +1,86 @@
+/**
+ * Hook system types for social-cli dispatch pipeline.
+ *
+ * Three lifecycle points:
+ *   preDispatch  — sync, blocking. Exit 0=pass, 1=skip action, 2=abort dispatch.
+ *   postDispatch — async, fire-and-forget. Logged but non-blocking.
+ *   onError      — async. Fired after a failed action.
+ */
+
+/** Action types that hooks can match against. */
+export type HookEvent =
+  | "reply"
+  | "post"
+  | "thread"
+  | "follow"
+  | "like"
+  | "annotate"
+  | "bookmark"
+  | "highlight"
+  | "*"
+
+/** The lifecycle point where a hook fires. */
+export type HookLifecycle = "preDispatch" | "postDispatch" | "onError"
+
+/** A single hook definition from config. */
+export interface HookDefinition {
+  /** Which action event(s) to match. "*" matches all. */
+  event: HookEvent
+  /** Shell command to execute. */
+  command: string
+  /** Timeout in seconds (default: 30 for pre, 60 for post). */
+  timeout?: number
+}
+
+/** Hook configuration section in config.yaml. */
+export interface HooksConfig {
+  preDispatch?: HookDefinition[]
+  postDispatch?: HookDefinition[]
+  onError?: HookDefinition[]
+}
+
+/** Context passed to every hook via environment variables. */
+export interface HookContext {
+  /** The action type that triggered the hook. */
+  event: string
+  /** Platform (bsky, x, etc). */
+  platform: string
+  /** Created resource ID (post-dispatch only, empty for pre). */
+  actionId?: string
+  /** Parent post ID for replies. */
+  targetId?: string
+  /** The post/reply text content. */
+  text?: string
+  /** Path to the outbox file being dispatched. */
+  outboxPath?: string
+  /** "success" or "error". */
+  result: "success" | "error"
+  /** Error message (onError hooks only). */
+  error?: string
+}
+
+/** Result of running a single hook. */
+export interface HookResult {
+  /** The hook definition that was run. */
+  hook: HookDefinition
+  /** Whether the hook completed within timeout. */
+  timedOut: boolean
+  /** Hook exit code. */
+  exitCode: number | null
+  /** Captured stdout. */
+  stdout: string
+  /** Captured stderr. */
+  stderr: string
+}
+
+/** Aggregate result of running all hooks for a lifecycle point. */
+export interface HookRunResult {
+  /** Results for each individual hook. */
+  results: HookResult[]
+  /** Whether any hook requested a block (preDispatch: exit 1 or 2). */
+  blocked: boolean
+  /** Whether any hook requested a hard abort (exit 2). */
+  abort: boolean
+  /** Block/abort reason (stdout from the blocking hook). */
+  reason?: string
+}


### PR DESCRIPTION
## Summary

Closes #39

Adds configurable lifecycle hooks to the dispatch pipeline with three trigger points:

- **preDispatch** — synchronous, blocking. Exit 0=pass, 1=skip action, 2=abort entire dispatch.
- **postDispatch** — async, fire-and-forget. Runs after successful actions. Errors logged but non-blocking.
- **onError** — async. Runs after failed actions. For alerting, retry logic, logging.

Hooks are matched by event type (`reply`, `post`, `thread`, `follow`, `like`, `annotate`, `bookmark`, `highlight`) or wildcard `*`. Context is passed via environment variables.

## Usage

```yaml
# config.yaml
hooks:
  preDispatch:
    - event: reply
      command: "bash hooks/validate-reply.sh"
      timeout: 30
  postDispatch:
    - event: thread
      command: "npx tsx skills/semble-sources/scripts/cite-sources.ts --input {sources_file}"
    - event: "*"
      command: "bash hooks/log-dispatch.sh"
  onError:
    - event: "*"
      command: "bash hooks/alert-error.sh"
```

### Environment variables

Every hook receives: `SOCIAL_HOOK_EVENT`, `SOCIAL_HOOK_PLATFORM`, `SOCIAL_HOOK_ACTION_ID`, `SOCIAL_HOOK_TARGET_ID`, `SOCIAL_HOOK_TEXT`, `SOCIAL_HOOK_OUTBOX_PATH`, `SOCIAL_HOOK_RESULT`.

## Files changed

| File | Change |
|------|--------|
| `src/types/hooks.ts` | New. Hook type definitions |
| `src/hooks.ts` | New. Hook runner (load config, match events, execute, handle exit codes) |
| `src/config.ts` | Added `hooks` to Config interface |
| `src/commands/dispatch.ts` | Wired pre/post/error hooks into action loop |

## Test plan

- [ ] Configure a preDispatch hook that exits 1 — verify action is skipped
- [ ] Configure a preDispatch hook that exits 2 — verify dispatch aborts
- [ ] Configure a postDispatch hook — verify it fires after successful actions
- [ ] Configure an onError hook — verify it fires after failed actions
- [ ] Run dispatch with no hooks configured — verify no behavior change

👾 Generated with [Letta Code](https://letta.com)