### PR TITLE
fix: prune inbox notifications when replying via reply/post commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -125,6 +125,9 @@ program
     if (opts.replyTo) {
       const result = await platform.reply(opts.replyTo, text, { quoteId: opts.quote, media: opts.media })
       console.log(`Posted (reply): ${result.id}`)
+      const { pruneInboxByPostId } = await import("./lib/state.js")
+      const pruned = pruneInboxByPostId(opts.platform, [opts.replyTo])
+      if (pruned.length > 0) console.log(`Pruned ${pruned.length} inbox notification(s) matching reply target`)
     } else {
       const result = await platform.post(text, { quoteId: opts.quote, media: opts.media })
       console.log(`Posted: ${result.id}`)
@@ -146,6 +149,9 @@ program
     const platform = await getPlatformAsync(opts.platform)
     const result = await platform.reply(opts.id, text, { media: opts.media })
     console.log(`Replied: ${result.id}`)
+    const { pruneInboxByPostId } = await import("./lib/state.js")
+    const pruned = pruneInboxByPostId(opts.platform, [opts.id])
+    if (pruned.length > 0) console.log(`Pruned ${pruned.length} inbox notification(s) matching reply target`)
   })
 
 // thread: Post a thread

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -231,6 +231,57 @@ export function readSharedFile<T = any>(
 }
 
 /**
+ * Remove notifications from a platform's inbox by matching post IDs.
+ *
+ * Matches on both `id` and `postId` fields of each notification (mirrors how
+ * dispatch prunes the inbox). Used by ad-hoc commands like `reply` that bypass
+ * the dispatch pipeline but still respond to inbox items, so the inbox doesn't
+ * keep showing those notifications as pending.
+ *
+ * Best-effort: silently returns [] if the inbox file is missing, malformed,
+ * or cannot be written. Never throws.
+ *
+ * @returns the list of notification ids that were removed
+ */
+export function pruneInboxByPostId(
+  platform: string,
+  postIds: string[],
+  stateDir?: string
+): string[] {
+  if (postIds.length === 0) return []
+
+  const path = getPlatformFilePath("inbox", platform, stateDir)
+  if (!existsSync(path)) return []
+
+  try {
+    const inbox = parse(readFileSync(path, "utf-8")) as {
+      notifications?: Array<{ id: string; postId?: string }>
+      _sync?: Record<string, unknown>
+    }
+    if (!inbox?.notifications?.length) return []
+
+    const matchSet = new Set(postIds)
+    const before = inbox.notifications
+    const removed = before.filter(
+      (n) => matchSet.has(n.id) || matchSet.has(n.postId ?? ""),
+    )
+    if (removed.length === 0) return []
+
+    const remaining = before.filter(
+      (n) => !matchSet.has(n.id) && !matchSet.has(n.postId ?? ""),
+    )
+    inbox.notifications = remaining
+    if (inbox._sync) {
+      inbox._sync = { ...inbox._sync, totalCount: remaining.length }
+    }
+    writeFileAtomic(path, stringify(inbox, { lineWidth: 120 }))
+    return removed.map((n) => n.id)
+  } catch {
+    return []
+  }
+}
+
+/**
  * Archive a platform-specific outbox file after dispatch.
  */
 export function archivePlatformOutbox(


### PR DESCRIPTION
## Summary

- The dispatch pipeline prunes `inbox-{platform}.yaml` when it processes notifications, but direct `reply` and `post --reply-to` bypassed that. Old notifications kept reappearing as pending even after they'd been answered.
- Today this caused a near-double-post: aglauros asked for self-sensemaking April 15, I delivered the thread earlier today, then the inbox still showed the original request as unprocessed and I almost acked it a second time.

## Changes

- `src/lib/state.ts`: new `pruneInboxByPostId(platform, postIds, stateDir?)` helper. Mirrors dispatch's inbox filtering (matches on both `id` and `postId`). Silent best-effort — returns `[]` if the inbox is missing, malformed, or unwritable.
- `src/cli.ts`: `reply` and `post --reply-to` call the helper after a successful reply and print a one-line summary if anything was pruned.

## Test plan

- [x] Typecheck passes (`npx tsc --noEmit`)
- [x] CLI help still renders
- [x] Manual: invoked `pruneInboxByPostId` against a just-replied-to notification — removed correctly, inbox YAML shrank, `_sync.totalCount` updated
- [x] No-op when the inbox doesn't contain the post ID (common case for replies to posts that were never notifications)

👾 Generated with [Letta Code](https://letta.com)