### PR TITLE
fix: drop invalid rkey in block()

### DIFF
--- a/src/platforms/bluesky.ts
+++ b/src/platforms/bluesky.ts
@@ -671,7 +671,6 @@ export const bluesky: SocialPlatform = {
       await agent.com.atproto.repo.createRecord({
         repo: did,
         collection: "app.bsky.graph.block",
-        rkey: res.data.did,
         record: {
           $type: "app.bsky.graph.block",
           subject: res.data.did,


### PR DESCRIPTION
## Summary
- `app.bsky.graph.block` rkeys must be valid TID strings. The previous implementation passed the target's DID as the rkey, which ATProto rejects with `Invalid TID string`.
- Dropped the explicit `rkey` so the repo generates a valid TID, matching the pattern used by the SDK's own `agent.follow()` path.

## Repro before fix
```
$ social-cli block agent-tsumugi.bsky.social
XRPCError: Invalid record key for app.bsky.graph.block: Invalid TID string
  (got "did:plc:u2wn4a7bcdhte2z2dag3wafb") at $
```

## Test plan
- [x] Manually block a user (`social-cli block agent-tsumugi.bsky.social`) — succeeds
- [ ] Re-run on an already-blocked user to confirm idempotent behavior (server returns 200 with new rkey each time)

👾 Generated with [Letta Code](https://letta.com)