### PR TITLE
docs: clarify X credential setup

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -6,7 +6,25 @@ This guide tells you everything you need to operate it.
 
 ## Setup
 
-The tool must be run from a working directory containing a `.env` with platform credentials. You do not need to manage credentials — they are pre-configured. If a command fails with an auth error, tell your operator.
+The tool must be run from a working directory containing a `.env` with platform credentials.
+
+For X, the provider expects **OAuth 1.0a user credentials**, not OAuth 2.0 client credentials. The required env vars are:
+
+```bash
+X_API_KEY
+X_API_SECRET
+X_ACCESS_TOKEN
+X_ACCESS_TOKEN_SECRET
+```
+
+In the X developer portal, these map to the **OAuth 1.0 Keys** section:
+
+- Consumer Key → `X_API_KEY`
+- Consumer Secret → `X_API_SECRET`
+- Access Token → `X_ACCESS_TOKEN`
+- Access Token Secret → `X_ACCESS_TOKEN_SECRET`
+
+If a command fails with an auth error, tell your operator.
 
 ## Core Loop
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,21 @@ ATPROTO_HANDLE=you.bsky.social
 ATPROTO_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
 ATPROTO_PDS=https://bsky.social        # optional, defaults to bsky.social
 
-# X / Twitter (OAuth 1.0a)
+# X / Twitter (OAuth 1.0a user auth)
+# X developer portal → Keys and tokens → OAuth 1.0 Keys
+# Consumer Key         → X_API_KEY
+# Consumer Secret      → X_API_SECRET
+# Access Token         → X_ACCESS_TOKEN
+# Access Token Secret  → X_ACCESS_TOKEN_SECRET
 X_API_KEY=...
 X_API_SECRET=...
 X_ACCESS_TOKEN=...
 X_ACCESS_TOKEN_SECRET=...
-X_BEARER_TOKEN=...                      # optional, for app-only endpoints
 ```
+
+For the X integration, use the **OAuth 1.0 Keys** section in the X developer portal. Do **not** use the OAuth 2.0 client ID / client secret fields for `social-cli`.
+
+`X_BEARER_TOKEN` is not part of the normal `social-cli` X setup flow and is not used by the main X provider path.
 
 You only need the credentials for the platforms you use. Semble, margin annotations, and GreenGale blog publishing all use your Bluesky credentials.
 


### PR DESCRIPTION
## Summary
- document that the X integration uses OAuth 1.0a user credentials
- map the X developer portal field names to the env vars social-cli expects
- clarify that OAuth 2.0 client credentials are not used for the main X provider flow
- remove the misleading implication that `X_BEARER_TOKEN` is part of normal setup

"The map is not the territory." — Alfred Korzybski
Written by Cameron ◯ Letta Code