### PR TITLE
fix(bluesky): surface video embeds in posts/sync output

### DIFF
--- a/src/platforms/bluesky.test.ts
+++ b/src/platforms/bluesky.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for extractEmbed: normalizes Bluesky post embeds into EmbedInfo.
+ *
+ * Regression coverage for video embeds, which were silently dropped before
+ * fix/bsky-video-embed. The previous behavior caused video posts to surface
+ * as text-only in `posts`/`sync` output.
+ */
+
+import { describe, it, expect } from "vitest"
+import { extractEmbed } from "./bluesky.js"
+
+describe("extractEmbed", () => {
+  it("returns undefined for missing or untyped input", () => {
+    expect(extractEmbed(undefined)).toBeUndefined()
+    expect(extractEmbed(null)).toBeUndefined()
+    expect(extractEmbed({})).toBeUndefined()
+    expect(extractEmbed({ images: [] })).toBeUndefined()
+  })
+
+  it("normalizes external link embeds", () => {
+    const result = extractEmbed({
+      $type: "app.bsky.embed.external#view",
+      external: {
+        uri: "https://example.com/article",
+        title: "Article title",
+        description: "Some description",
+      },
+    })
+    expect(result).toEqual({
+      type: "external",
+      uri: "https://example.com/article",
+      title: "Article title",
+      description: "Some description",
+    })
+  })
+
+  it("normalizes image embeds", () => {
+    const result = extractEmbed({
+      $type: "app.bsky.embed.images#view",
+      images: [
+        { alt: "alt 1", fullsize: "https://cdn.bsky.app/img/full/1", thumb: "https://cdn.bsky.app/img/thumb/1" },
+        { alt: "", thumb: "https://cdn.bsky.app/img/thumb/2" },
+      ],
+    })
+    expect(result).toEqual({
+      type: "images",
+      images: [
+        { alt: "alt 1", url: "https://cdn.bsky.app/img/full/1" },
+        { alt: "", url: "https://cdn.bsky.app/img/thumb/2" },
+      ],
+    })
+  })
+
+  it("normalizes record (quote) embeds", () => {
+    const result = extractEmbed({
+      $type: "app.bsky.embed.record#view",
+      record: {
+        uri: "at://did:plc:xxx/app.bsky.feed.post/3kqr",
+        value: { text: "Quoted post text" },
+        author: { handle: "alice.bsky.social" },
+      },
+    })
+    expect(result).toEqual({
+      type: "record",
+      quotedUri: "at://did:plc:xxx/app.bsky.feed.post/3kqr",
+      quotedText: "Quoted post text",
+      quotedAuthor: "alice.bsky.social",
+    })
+  })
+
+  it("normalizes video embeds", () => {
+    // Real-world shape from Cameron's "Letta is not a memory layer" post.
+    const result = extractEmbed({
+      $type: "app.bsky.embed.video#view",
+      cid: "bafkreidoq6kpvrhavckscpmjtmpwke6vklcbxis42a5xcaqj6afcn5ujhu",
+      playlist:
+        "https://video.bsky.app/watch/did%3Aplc%3Agfrmhdmjvxn2sjedzboeudef/bafkreidoq.../playlist.m3u8",
+      thumbnail:
+        "https://video.bsky.app/watch/did%3Aplc%3Agfrmhdmjvxn2sjedzboeudef/bafkreidoq.../thumbnail.jpg",
+      alt: "",
+      aspectRatio: { height: 1920, width: 1080 },
+    })
+    expect(result).toEqual({
+      type: "video",
+      playlist:
+        "https://video.bsky.app/watch/did%3Aplc%3Agfrmhdmjvxn2sjedzboeudef/bafkreidoq.../playlist.m3u8",
+      thumbnail:
+        "https://video.bsky.app/watch/did%3Aplc%3Agfrmhdmjvxn2sjedzboeudef/bafkreidoq.../thumbnail.jpg",
+      videoAlt: undefined,
+      aspectRatio: { height: 1920, width: 1080 },
+    })
+  })
+
+  it("preserves video alt text when present", () => {
+    const result = extractEmbed({
+      $type: "app.bsky.embed.video#view",
+      playlist: "https://video.bsky.app/x/playlist.m3u8",
+      thumbnail: "https://video.bsky.app/x/thumbnail.jpg",
+      alt: "Cameron explaining Letta architecture",
+      aspectRatio: { height: 1080, width: 1920 },
+    })
+    expect(result?.videoAlt).toBe("Cameron explaining Letta architecture")
+  })
+
+  it("normalizes recordWithMedia + images", () => {
+    const result = extractEmbed({
+      $type: "app.bsky.embed.recordWithMedia#view",
+      record: {
+        record: {
+          uri: "at://did:plc:xxx/app.bsky.feed.post/3kqr",
+          value: { text: "Quoted text" },
+          author: { handle: "bob.bsky.social" },
+        },
+      },
+      media: {
+        $type: "app.bsky.embed.images#view",
+        images: [{ alt: "image alt", fullsize: "https://cdn.bsky.app/img/full/1" }],
+      },
+    })
+    expect(result).toEqual({
+      type: "recordWithMedia",
+      quotedUri: "at://did:plc:xxx/app.bsky.feed.post/3kqr",
+      quotedText: "Quoted text",
+      quotedAuthor: "bob.bsky.social",
+      images: [{ alt: "image alt", url: "https://cdn.bsky.app/img/full/1" }],
+    })
+  })
+
+  it("normalizes recordWithMedia + video", () => {
+    const result = extractEmbed({
+      $type: "app.bsky.embed.recordWithMedia#view",
+      record: {
+        record: {
+          uri: "at://did:plc:xxx/app.bsky.feed.post/3kqr",
+          value: { text: "Quoted text" },
+          author: { handle: "carol.bsky.social" },
+        },
+      },
+      media: {
+        $type: "app.bsky.embed.video#view",
+        playlist: "https://video.bsky.app/watch/x/playlist.m3u8",
+        thumbnail: "https://video.bsky.app/watch/x/thumbnail.jpg",
+        alt: "Caption",
+        aspectRatio: { height: 1080, width: 1920 },
+      },
+    })
+    expect(result).toEqual({
+      type: "recordWithMedia",
+      quotedUri: "at://did:plc:xxx/app.bsky.feed.post/3kqr",
+      quotedText: "Quoted text",
+      quotedAuthor: "carol.bsky.social",
+      playlist: "https://video.bsky.app/watch/x/playlist.m3u8",
+      thumbnail: "https://video.bsky.app/watch/x/thumbnail.jpg",
+      videoAlt: "Caption",
+      aspectRatio: { height: 1080, width: 1920 },
+    })
+  })
+
+  it("normalizes recordWithMedia + external link", () => {
+    const result = extractEmbed({
+      $type: "app.bsky.embed.recordWithMedia#view",
+      record: {
+        record: {
+          uri: "at://did:plc:xxx/app.bsky.feed.post/3kqr",
+          value: { text: "Quoted text" },
+          author: { handle: "dan.bsky.social" },
+        },
+      },
+      media: {
+        $type: "app.bsky.embed.external#view",
+        external: {
+          uri: "https://example.com/article",
+          title: "Article",
+          description: "Description",
+        },
+      },
+    })
+    expect(result?.uri).toBe("https://example.com/article")
+    expect(result?.title).toBe("Article")
+    expect(result?.quotedAuthor).toBe("dan.bsky.social")
+  })
+
+  it("returns undefined for unrecognized embed types", () => {
+    expect(extractEmbed({ $type: "app.bsky.embed.something.unknown" })).toBeUndefined()
+  })
+})

--- a/src/platforms/bluesky.ts
+++ b/src/platforms/bluesky.ts
@@ -87,7 +87,7 @@ async function withSession<T>(fn: (agent: Agent) => Promise<T>): Promise<T> {
 }
 
 /** Extract embed info from a post's embed view object. */
-function extractEmbed(embed: any): EmbedInfo | undefined {
+export function extractEmbed(embed: any): EmbedInfo | undefined {
   if (!embed?.$type) return undefined
 
   switch (embed.$type) {
@@ -119,7 +119,7 @@ function extractEmbed(embed: any): EmbedInfo | undefined {
     }
 
     case "app.bsky.embed.recordWithMedia#view": {
-      // Combination of record + media (images or external link)
+      // Combination of record + media (images, video, or external link)
       const info: EmbedInfo = { type: "recordWithMedia" }
       // Extract the record portion
       const innerRec = embed.record?.record ?? embed.record
@@ -139,9 +139,23 @@ function extractEmbed(embed: any): EmbedInfo | undefined {
         info.uri = media.external?.uri
         info.title = media.external?.title
         info.description = media.external?.description || undefined
+      } else if (media?.$type === "app.bsky.embed.video#view") {
+        info.playlist = media.playlist
+        info.thumbnail = media.thumbnail
+        info.videoAlt = media.alt || undefined
+        info.aspectRatio = media.aspectRatio
       }
       return info
     }
+
+    case "app.bsky.embed.video#view":
+      return {
+        type: "video",
+        playlist: embed.playlist,
+        thumbnail: embed.thumbnail,
+        videoAlt: embed.alt || undefined,
+        aspectRatio: embed.aspectRatio,
+      }
 
     default:
       return undefined

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -66,7 +66,7 @@ export interface Notification {
 }
 
 export interface EmbedInfo {
-  type: "external" | "images" | "record" | "recordWithMedia"
+  type: "external" | "images" | "record" | "recordWithMedia" | "video"
   /** External link URL. */
   uri?: string
   /** External link title. */
@@ -81,6 +81,14 @@ export interface EmbedInfo {
   quotedText?: string
   /** Quoted post author handle. */
   quotedAuthor?: string
+  /** Video HLS playlist URL (m3u8). */
+  playlist?: string
+  /** Video thumbnail JPG URL. */
+  thumbnail?: string
+  /** Video alt text. */
+  videoAlt?: string
+  /** Video aspect ratio. */
+  aspectRatio?: { width: number; height: number }
 }
 
 export interface SearchResult {


### PR DESCRIPTION
## Summary

\`extractEmbed\` silently dropped \`app.bsky.embed.video#view\` because the switch had no case for it — only external/images/record/recordWithMedia were handled. The default fall-through returned undefined, so video posts looked text-only in YAML output of \`posts\` and \`sync\`.

## What changed

- Added \`\"video\"\` to \`EmbedInfo\` type union with \`playlist\`, \`thumbnail\`, \`videoAlt\`, \`aspectRatio\` fields
- Direct video case in \`extractEmbed\`
- Video media branch in \`recordWithMedia\` handling (covers quote-posts with attached video)
- Exported \`extractEmbed\` so it can be unit-tested
- New \`bluesky.test.ts\` with 10 cases covering all embed types, including a regression test built from the actual shape returned by \`getPostThread\` for a video-bearing post

## Why

Caught publicly when a user tagged Sensemaker on a video post and the agent replied \"there's no video.\" There was — the tooling stripped it. Then the user (correctly) called the bluff, and the only honest answer was \"my tooling didn't surface video embeds.\"

## Verification

\`\`\`
$ bun run src/cli.ts posts cameron.stream -p bsky -n 30 | grep -A12 \"3mkigsyqxh72a\"
- platform: bsky
  id: at://did:plc:gfrmhdmjvxn2sjedzboeudef/app.bsky.feed.post/3mkigsyqxh72a
  author: cameron.stream
  text: Letta is not a memory layer.
  ...
  embed:
    type: video
    playlist: https://video.bsky.app/.../playlist.m3u8
    thumbnail: https://video.bsky.app/.../thumbnail.jpg
    aspectRatio: { height: 1920, width: 1080 }
\`\`\`

## Test plan

- [x] All 41 existing tests still pass
- [x] 10 new tests pass (covering all embed types)
- [x] \`tsc\` clean
- [x] Verified end-to-end against a real video-bearing post
- [ ] Reviewer to spot-check that the type addition doesn't break any consumers of \`EmbedInfo.type\`

🤖 Generated with [Letta Code](https://letta.com)