### PR TITLE
feat: add publish command for long-form documents via Leaflet's lexicons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.letta/
 .env
 .env.*
 inbox.yaml

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -325,3 +325,28 @@ When processing inbox notifications:
 | `posts` | User's recent posts | stdout YAML |
 | `whoami` | Current account info | stdout YAML |
 | `rate-limits` | Rate limit status | stdout YAML |
+
+## Long-form publishing
+
+Use `publish` for Leaflet / Standard.site documents. This writes a `site.standard.document` record with embedded `pub.leaflet.content` to the configured Bluesky PDS.
+
+```bash
+social-cli publish --file essay.md --publication at://did:plc:.../site.standard.publication/...
+social-cli publish --file essay.md --dry-run
+social-cli publish --title "Quick Note" --content "Markdown content here"
+```
+
+The command requires either `--publication <at-uri>` or `LEAFLET_PUBLICATION_URI` in the environment. File input supports frontmatter:
+
+```markdown
+---
+title: My Essay
+description: Short excerpt
+tags: ai, agents, atproto
+slug: my-essay
+---
+```
+
+Supported markdown: paragraphs, ATX headings, inline links, bold, italic, inline code, and standalone PNG/JPEG/WebP images (`![alt](path)`). Images are uploaded as PDS blobs and must satisfy Leaflet's blob size limits.
+
+By default, `publish` uses the slug as the record rkey so `{publication-domain}/{slug}` resolves. Use `--rkey tid` only when a generated TID rkey and deep Leaflet permalink are acceptable.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # social-cli
 
-A unified CLI to connect AI agents to the social web. Bluesky, X, Semble, margin annotations, and blog publishing — all through one tool. YAML in, YAML out.
+A unified CLI to connect AI agents to the social web. Bluesky, X, Semble, margin annotations, and long-form publishing — all through one tool. YAML in, YAML out.
 
 Built for [Letta](https://letta.com) agents, works with anything that can shell out. Available as a bundled skill in [Letta Code Desktop](https://letta.com).
 
@@ -51,7 +51,13 @@ For the X integration, use the **OAuth 1.0 Keys** section in the X developer por
 
 `X_BEARER_TOKEN` is not part of the normal `social-cli` X setup flow and is not used by the main X provider path.
 
-You only need the credentials for the platforms you use. Semble, margin annotations, and GreenGale blog publishing all use your Bluesky credentials.
+You only need the credentials for the platforms you use. Semble, margin annotations, GreenGale blog publishing, and Leaflet publishing all use your Bluesky credentials.
+
+For Leaflet publishing, either pass `--publication <at-uri>` on each publish or set:
+
+```bash
+LEAFLET_PUBLICATION_URI=at://did:plc:.../site.standard.publication/...
+```
 
 ## How it works
 
@@ -188,6 +194,39 @@ social-cli blog --title "Quick Note" --content "Markdown content here"
 ```
 
 Supports frontmatter (`title`, `slug`, `subtitle`). Published at `greengale.app/{handle}/{slug}`.
+
+### Leaflet publishing
+
+Publish long-form documents to [Leaflet](https://leaflet.pub) using ATProto records (`site.standard.document` with embedded `pub.leaflet.content`):
+
+```bash
+social-cli publish --file essay.md --publication at://did:plc:.../site.standard.publication/...
+social-cli publish --file essay.md --dry-run
+social-cli publish --title "Quick Note" --content "Markdown content here"
+```
+
+Supports frontmatter:
+
+```markdown
+---
+title: My Essay
+description: Short excerpt
+tags: ai, agents, atproto
+slug: my-essay
+---
+
+# My Essay
+
+Markdown body...
+```
+
+Supported markdown maps to Leaflet blocks and rich-text facets:
+
+- paragraphs and ATX headings (`#`, `##`, ...)
+- inline links, bold, italic, and inline code
+- standalone images (`![alt](path)`) as uploaded PNG/JPEG/WebP blobs
+
+By default, the document rkey is the slug so canonical Leaflet URLs like `{publication-domain}/{slug}` resolve. Use `--rkey tid` for a generated TID rkey when you only need the deep Leaflet permalink.
 
 ## Embed data
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -534,4 +534,32 @@ program
     })
   })
 
+// publish: Publish long-form essays to ATProto (site.standard.document + pub.leaflet.content)
+program
+  .command("publish")
+  .description("Publish a document via site.standard.document with pub.leaflet.content (renders on Leaflet)")
+  .option("-t, --title <title>", "Document title")
+  .option("-d, --description <text>", "Short description / excerpt")
+  .option("--tags <tags>", "Comma-separated tags")
+  .option("-f, --file <path>", "Markdown file (frontmatter supported)")
+  .option("-c, --content <text>", "Raw markdown content (use with --title)")
+  .option("--rkey <rkey>", "Custom rkey (for updating an existing document)")
+  .option("--slug <slug>", "URL slug (default: slugified title)")
+  .option("--publication <at-uri>", "Publication AT-URI (defaults to env or sensemaker)")
+  .option("--dry-run", "Print the record without writing to PDS")
+  .action(async (opts) => {
+    const { publish } = await import("./commands/publish.js")
+    await publish({
+      title: opts.title,
+      description: opts.description,
+      tags: opts.tags,
+      file: opts.file,
+      content: opts.content,
+      rkey: opts.rkey,
+      slug: opts.slug,
+      publication: opts.publication,
+      dryRun: opts.dryRun,
+    })
+  })
+
 program.parse()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -545,7 +545,7 @@ program
   .option("-c, --content <text>", "Raw markdown content (use with --title)")
   .option("--rkey <rkey>", "Custom rkey (for updating an existing document)")
   .option("--slug <slug>", "URL slug (default: slugified title)")
-  .option("--publication <at-uri>", "Publication AT-URI (defaults to env or sensemaker)")
+  .option("--publication <at-uri>", "Publication AT-URI (or set LEAFLET_PUBLICATION_URI env var)")
   .option("--dry-run", "Print the record without writing to PDS")
   .action(async (opts) => {
     const { publish } = await import("./commands/publish.js")

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,0 +1,446 @@
+/**
+ * publish: Publish long-form documents to ATProto via site.standard.document
+ *
+ * Writes a `site.standard.document` record with embedded `pub.leaflet.content`
+ * to the agent's PDS. Leaflet's appview indexes records on the PDS and renders
+ * them at leaflet.pub/reader (and on the publication's domain if configured).
+ *
+ * Schema reference (from github.com/hyperlink-academy/leaflet/lexicons):
+ *   site.standard.document — wrapper (required: site, title, publishedAt)
+ *     content — pub.leaflet.content (required: pages array)
+ *       pages[] — pub.leaflet.pages.linearDocument (required: blocks array)
+ *         blocks[] — { block: pub.leaflet.blocks.*, alignment? }
+ *
+ * MVP: paragraphs (`pub.leaflet.blocks.text`) and ATX headings
+ * (`pub.leaflet.blocks.header`) only. Markdown formatting (bold/italic/links)
+ * is stripped, not rendered as facets — followups in
+ * reference/sensemaker/followups/social-cli-publish.md.
+ */
+
+import { readFileSync, existsSync } from "node:fs"
+import { loadConfig, loadCredentials } from "../config.js"
+
+interface PublishOptions {
+  title?: string
+  description?: string
+  tags?: string
+  file?: string
+  content?: string
+  rkey?: string
+  slug?: string
+  publication?: string
+  dryRun?: boolean
+}
+
+interface FrontmatterFields {
+  title?: string
+  description?: string
+  tags?: string
+  slug?: string
+  rkey?: string
+}
+
+interface LeafletTextBlock {
+  $type: "pub.leaflet.blocks.text"
+  plaintext: string
+  textSize?: "default" | "small" | "large"
+}
+
+interface LeafletHeaderBlock {
+  $type: "pub.leaflet.blocks.header"
+  level: number
+  plaintext: string
+}
+
+type LeafletBlock = LeafletTextBlock | LeafletHeaderBlock
+
+interface LeafletPageBlock {
+  $type: "pub.leaflet.pages.linearDocument#block"
+  block: LeafletBlock
+  alignment?: "#textAlignLeft" | "#textAlignCenter" | "#textAlignRight" | "#textAlignJustify"
+}
+
+interface LeafletLinearDocument {
+  $type: "pub.leaflet.pages.linearDocument"
+  id?: string
+  blocks: LeafletPageBlock[]
+}
+
+interface LeafletContent {
+  $type: "pub.leaflet.content"
+  pages: LeafletLinearDocument[]
+}
+
+interface SiteStandardDocument {
+  $type: "site.standard.document"
+  site: string
+  title: string
+  publishedAt: string
+  description?: string
+  tags?: string[]
+  path?: string
+  textContent?: string
+  content?: LeafletContent
+}
+
+interface PublishResult {
+  success: boolean
+  uri?: string
+  cid?: string
+  url?: string
+  rkey?: string
+  record?: SiteStandardDocument
+  error?: string
+}
+
+const DEFAULT_PUBLICATION_URI =
+  "at://did:plc:4j7exarb62djxycrgdfhuulr/site.standard.publication/3ml7mt7p7gq2u"
+const TID_LAST_TIMESTAMP = { value: 0 }
+
+/**
+ * Generate a TID-format rkey (atproto's sortable timestamp identifier).
+ * Format: 13 base32-sortable chars derived from microsecond timestamp + clock id.
+ * Spec: https://atproto.com/specs/tid
+ */
+function generateTid(): string {
+  // base32-sortable alphabet (lower 5 bits, sortable as string)
+  const ALPHABET = "234567abcdefghijklmnopqrstuvwxyz"
+  // microsecond timestamp (53-bit safe integer)
+  let now = Date.now() * 1000 + Math.floor((performance.now() % 1) * 1000)
+  if (now <= TID_LAST_TIMESTAMP.value) {
+    now = TID_LAST_TIMESTAMP.value + 1
+  }
+  TID_LAST_TIMESTAMP.value = now
+  // 10-bit random clock identifier
+  const clockId = Math.floor(Math.random() * 1024)
+  // 64-bit value: top bit = 0, next 53 = timestamp, last 10 = clockId
+  const bigVal = (BigInt(now) << 10n) | BigInt(clockId)
+  // Encode as 13 base32 chars (65 bits but top bit is 0)
+  let out = ""
+  let v = bigVal
+  for (let i = 0; i < 13; i++) {
+    out = ALPHABET[Number(v & 31n)] + out
+    v = v >> 5n
+  }
+  return out
+}
+
+/**
+ * Slugify a title for URL paths. Lowercase, alphanumeric + hyphens only.
+ */
+function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 60)
+}
+
+/**
+ * Strip markdown formatting from a string (best effort).
+ * Removes: **bold**, __bold__, *italic*, _italic_, `code`, [text](url) → text,
+ * <link> autolinks → link, escape sequences.
+ *
+ * Future work: instead of stripping, parse these into pub.leaflet.richtext.facet
+ * features. See reference/sensemaker/followups/social-cli-publish.md.
+ */
+function stripMarkdown(text: string): string {
+  return text
+    // links: [text](url) → text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    // bold: **text** or __text__
+    .replace(/(\*\*|__)(.+?)\1/g, "$2")
+    // italic: *text* or _text_ (avoid matching inside words)
+    .replace(/(?<!\w)([*_])([^*_\n]+?)\1(?!\w)/g, "$2")
+    // inline code: `text`
+    .replace(/`([^`]+)`/g, "$1")
+    // autolink: <https://...>
+    .replace(/<((?:https?|mailto):[^>]+)>/g, "$1")
+    // escaped chars: \* → *, \_ → _, etc.
+    .replace(/\\([\\`*_{}[\]()#+\-.!])/g, "$1")
+    .trim()
+}
+
+/**
+ * Convert a markdown body to an array of Leaflet page-blocks.
+ *
+ * MVP scope:
+ * - ATX headings (`# heading`) → pub.leaflet.blocks.header
+ * - Paragraphs (everything else, separated by blank lines) → pub.leaflet.blocks.text
+ * - Blockquotes, lists, code blocks, images — flattened to plaintext for now
+ *
+ * Each block's plaintext has markdown formatting stripped (no facets in MVP).
+ */
+function markdownToBlocks(markdown: string): LeafletPageBlock[] {
+  const blocks: LeafletPageBlock[] = []
+  // Split on blank lines (one or more newlines with only whitespace between)
+  const paragraphs = markdown.split(/\n\s*\n/).map(p => p.trim()).filter(Boolean)
+
+  for (const para of paragraphs) {
+    // Heading? ATX form: 1-6 #s + space + text
+    const headingMatch = para.match(/^(#{1,6})\s+(.+?)\s*#*$/)
+    if (headingMatch && !para.includes("\n")) {
+      blocks.push({
+        $type: "pub.leaflet.pages.linearDocument#block",
+        block: {
+          $type: "pub.leaflet.blocks.header",
+          level: headingMatch[1].length,
+          plaintext: stripMarkdown(headingMatch[2]),
+        },
+      })
+      continue
+    }
+    // Otherwise: text block. Collapse internal newlines to single space.
+    const flat = para.replace(/\s*\n\s*/g, " ").trim()
+    blocks.push({
+      $type: "pub.leaflet.pages.linearDocument#block",
+      block: {
+        $type: "pub.leaflet.blocks.text",
+        plaintext: stripMarkdown(flat),
+      },
+    })
+  }
+
+  return blocks
+}
+
+/**
+ * Generate a UUIDv7-style identifier for the page id.
+ * Leaflet uses these — the `id` field on linearDocument helps with persistence.
+ */
+function generateUuidV7(): string {
+  const timestamp = Date.now()
+  const timestampHex = timestamp.toString(16).padStart(12, "0")
+  // Random bits for the rest (UUIDv7: timestamp + version + random)
+  const randomHex = Array.from({ length: 20 }, () =>
+    Math.floor(Math.random() * 16).toString(16)
+  ).join("")
+  // UUIDv7 format: xxxxxxxx-xxxx-7xxx-yxxx-xxxxxxxxxxxx
+  return [
+    timestampHex.slice(0, 8),
+    timestampHex.slice(8, 12),
+    "7" + randomHex.slice(0, 3),
+    ((parseInt(randomHex[3], 16) & 0x3) | 0x8).toString(16) + randomHex.slice(4, 7),
+    randomHex.slice(7, 19),
+  ].join("-")
+}
+
+/**
+ * Flatten page-blocks → plaintext for the document-level `textContent` field.
+ * Used by indexers (leaflet-search etc.) for full-text search.
+ */
+function blocksToTextContent(blocks: LeafletPageBlock[]): string {
+  return blocks.map(b => b.block.plaintext).join("\n")
+}
+
+/**
+ * Parse YAML-ish frontmatter (key: value pairs only, no nested structures).
+ * Reuses the same pattern as src/commands/blog.ts.
+ */
+function extractFrontmatter(content: string): { frontmatter: FrontmatterFields; body: string } {
+  if (!content.startsWith("---")) {
+    return { frontmatter: {}, body: content }
+  }
+  const endIndex = content.indexOf("---", 3)
+  if (endIndex === -1) {
+    return { frontmatter: {}, body: content }
+  }
+  const frontmatterStr = content.slice(3, endIndex).trim()
+  const body = content.slice(endIndex + 3).trim()
+
+  const frontmatter: FrontmatterFields = {}
+  for (const line of frontmatterStr.split("\n")) {
+    if (!line.includes(":")) continue
+    const [key, ...valueParts] = line.split(":")
+    const value = valueParts.join(":").trim().replace(/^["']|["']$/g, "")
+    const k = key.trim() as keyof FrontmatterFields
+    if (k === "title" || k === "description" || k === "tags" || k === "slug" || k === "rkey") {
+      frontmatter[k] = value
+    }
+  }
+  return { frontmatter, body }
+}
+
+async function createSession(
+  pds: string,
+  handle: string,
+  appPassword: string
+): Promise<{ accessJwt: string; did: string }> {
+  const response = await fetch(`${pds}/xrpc/com.atproto.server.createSession`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ identifier: handle, password: appPassword }),
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to create session: ${response.status} ${await response.text()}`)
+  }
+  const data = (await response.json()) as { accessJwt: string; did: string }
+  return { accessJwt: data.accessJwt, did: data.did }
+}
+
+async function publishDocument(opts: PublishOptions): Promise<PublishResult> {
+  const config = loadConfig()
+  loadCredentials("bsky", config)
+
+  const pds = process.env.ATPROTO_PDS || "https://bsky.social"
+  const handle = process.env.ATPROTO_HANDLE
+  const appPassword = process.env.ATPROTO_APP_PASSWORD
+
+  if (!handle || !appPassword) {
+    return {
+      success: false,
+      error: "Missing ATPROTO_HANDLE or ATPROTO_APP_PASSWORD environment variables",
+    }
+  }
+
+  // Resolve content + metadata
+  let body: string
+  let title = opts.title
+  let description = opts.description
+  let tagsRaw = opts.tags
+  let slug = opts.slug
+  let rkey = opts.rkey
+
+  if (opts.file) {
+    if (!existsSync(opts.file)) {
+      return { success: false, error: `File not found: ${opts.file}` }
+    }
+    const fileContent = readFileSync(opts.file, "utf-8")
+    const parsed = extractFrontmatter(fileContent)
+    body = parsed.body
+    title = title ?? parsed.frontmatter.title
+    description = description ?? parsed.frontmatter.description
+    tagsRaw = tagsRaw ?? parsed.frontmatter.tags
+    slug = slug ?? parsed.frontmatter.slug
+    rkey = rkey ?? parsed.frontmatter.rkey
+  } else if (opts.content) {
+    body = opts.content
+  } else {
+    return { success: false, error: "No content provided (use --file or --content)" }
+  }
+
+  if (!title) {
+    return { success: false, error: "No title provided (use --title or frontmatter)" }
+  }
+
+  // Defaults
+  if (!slug) slug = slugify(title)
+  if (!rkey) rkey = generateTid()
+  const publicationUri = opts.publication ?? process.env.PUBLICATION_URI ?? DEFAULT_PUBLICATION_URI
+
+  // Build blocks + content
+  const blocks = markdownToBlocks(body)
+  if (blocks.length === 0) {
+    return { success: false, error: "No content blocks parsed from body" }
+  }
+  const textContent = blocksToTextContent(blocks)
+
+  // Tags array (comma-separated → trimmed array, drop empties)
+  const tags = tagsRaw
+    ? tagsRaw.split(",").map(t => t.trim()).filter(Boolean)
+    : undefined
+
+  const now = new Date().toISOString()
+
+  const record: SiteStandardDocument = {
+    $type: "site.standard.document",
+    site: publicationUri,
+    title,
+    publishedAt: now,
+    path: `/${slug}`,
+    textContent,
+    content: {
+      $type: "pub.leaflet.content",
+      pages: [
+        {
+          $type: "pub.leaflet.pages.linearDocument",
+          id: generateUuidV7(),
+          blocks,
+        },
+      ],
+    },
+  }
+  if (description) record.description = description
+  if (tags && tags.length > 0) record.tags = tags
+
+  if (opts.dryRun) {
+    return {
+      success: true,
+      record,
+      rkey,
+    }
+  }
+
+  try {
+    const session = await createSession(pds, handle, appPassword)
+    const response = await fetch(`${pds}/xrpc/com.atproto.repo.putRecord`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${session.accessJwt}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        repo: session.did,
+        collection: "site.standard.document",
+        rkey,
+        record,
+      }),
+    })
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: `Failed to publish: ${response.status} ${await response.text()}`,
+      }
+    }
+
+    const result = (await response.json()) as { uri: string; cid: string }
+    // Construct rendered URL on Leaflet's appview.
+    // Pattern: leaflet.pub/lish/{did}/{publication-rkey}/{document-rkey}
+    // Requires a matching pub.leaflet.publication record at {publication-rkey}.
+    const pubRkey = publicationUri.split("/").pop() ?? ""
+    const url = `https://leaflet.pub/lish/${session.did}/${pubRkey}/${rkey}`
+    return {
+      success: true,
+      uri: result.uri,
+      cid: result.cid,
+      rkey,
+      url,
+      record,
+    }
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+export async function publish(opts: PublishOptions): Promise<void> {
+  const result = await publishDocument(opts)
+
+  if (opts.dryRun) {
+    if (!result.success) {
+      console.error(`Error: ${result.error}`)
+      process.exit(1)
+    }
+    console.log("[dry-run] rkey:", result.rkey)
+    console.log("[dry-run] record:")
+    console.log(JSON.stringify(result.record, null, 2))
+    process.exit(0)
+  }
+
+  if (result.success) {
+    console.log(`Published.`)
+    console.log(`URI: ${result.uri}`)
+    console.log(`CID: ${result.cid}`)
+    console.log(`rkey: ${result.rkey}`)
+    if (result.url) {
+      console.log(`URL: ${result.url}`)
+    }
+    process.exit(0)
+  } else {
+    console.error(`Error: ${result.error}`)
+    process.exit(1)
+  }
+}

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -93,8 +93,14 @@ interface PublishResult {
   error?: string
 }
 
+// sensemaker's Leaflet publication. The site.standard.publication record holds
+// the metadata Leaflet's appview reads (title, description, theme). The
+// matching pub.leaflet.publication record (created via Leaflet's UI) holds
+// the leaflet-native config (subdomain, preferences). Documents reference
+// the site.standard.publication via the `site` field.
 const DEFAULT_PUBLICATION_URI =
-  "at://did:plc:4j7exarb62djxycrgdfhuulr/site.standard.publication/3ml7mt7p7gq2u"
+  "at://did:plc:4j7exarb62djxycrgdfhuulr/site.standard.publication/3ml7tpkenes2j"
+const DEFAULT_PUBLICATION_DOMAIN = "https://sensemaker.leaflet.pub"
 const TID_LAST_TIMESTAMP = { value: 0 }
 
 /**
@@ -395,11 +401,14 @@ async function publishDocument(opts: PublishOptions): Promise<PublishResult> {
     }
 
     const result = (await response.json()) as { uri: string; cid: string }
-    // Construct rendered URL on Leaflet's appview.
-    // Pattern: leaflet.pub/lish/{did}/{publication-rkey}/{document-rkey}
-    // Requires a matching pub.leaflet.publication record at {publication-rkey}.
+    // Construct rendered URL. Prefer the publication's clean subdomain when
+    // we're publishing to sensemaker's default pub; otherwise fall back to
+    // the deep /lish/{did}/{pub-rkey}/{doc-rkey} permalink.
     const pubRkey = publicationUri.split("/").pop() ?? ""
-    const url = `https://leaflet.pub/lish/${session.did}/${pubRkey}/${rkey}`
+    const url =
+      publicationUri === DEFAULT_PUBLICATION_URI
+        ? `${DEFAULT_PUBLICATION_DOMAIN}/${rkey}`
+        : `https://leaflet.pub/lish/${session.did}/${pubRkey}/${rkey}`
     return {
       success: true,
       uri: result.uri,

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -419,7 +419,7 @@ async function uploadBlob(
       Authorization: `Bearer ${accessJwt}`,
       "Content-Type": mime,
     },
-    body: data,
+    body: data as unknown as BodyInit,
   })
   if (!response.ok) {
     throw new Error(`uploadBlob failed: ${response.status} ${await response.text()}`)
@@ -536,7 +536,15 @@ function generateUuidV7(): string {
  * Used by indexers (leaflet-search etc.) for full-text search.
  */
 function blocksToTextContent(blocks: LeafletPageBlock[]): string {
-  return blocks.map(b => b.block.plaintext).join("\n")
+  return blocks
+    .map(({ block }) => {
+      if (block.$type === "pub.leaflet.blocks.image") {
+        return block.alt ?? ""
+      }
+      return block.plaintext
+    })
+    .filter(Boolean)
+    .join("\n")
 }
 
 /**

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -581,7 +581,12 @@ async function publishDocument(opts: PublishOptions): Promise<PublishResult> {
 
   // Defaults
   if (!slug) slug = slugify(title)
-  if (!rkey) rkey = generateTid()
+  // Default rkey to the slug — Leaflet's URL lookup queries by rkey, while
+  // the canonical doc URL is {domain}/{path}. For both to resolve to the
+  // same record, rkey must equal the slug. Fall back to a TID rkey only if
+  // the user explicitly opts out via `--rkey tid` or sets one in frontmatter.
+  if (!rkey) rkey = slug
+  else if (rkey === "tid") rkey = generateTid()
   const publicationUri = opts.publication ?? process.env.LEAFLET_PUBLICATION_URI
   if (!publicationUri) {
     return {
@@ -687,12 +692,16 @@ async function publishDocument(opts: PublishOptions): Promise<PublishResult> {
     // Construct rendered URL. Prefer the publication's own `url` field
     // (typically a Leaflet subdomain like sensemaker.leaflet.pub or a
     // custom domain) so the link points at the publisher's chosen home.
-    // Fall back to the deep /lish/{did}/{pub-rkey}/{doc-rkey} permalink
-    // if the publication record doesn't expose a URL or can't be fetched.
+    // Use the doc's slug for the URL path — Leaflet's middleware rewrites
+    // {domain}/{slug} → /lish/{did}/{pub-rkey}/{slug} and looks up the
+    // record by rkey, so the slug must equal the rkey for this to resolve
+    // (which is what we ensure when defaulting rkey from slug above).
+    // Fall back to the deep /lish/{did}/{pub-rkey}/{rkey} permalink if the
+    // publication record can't be fetched or doesn't expose a URL.
     const pubRkey = publicationUri.split("/").pop() ?? ""
     const fallbackUrl = `https://leaflet.pub/lish/${session.did}/${pubRkey}/${rkey}`
     const pubDomain = await fetchPublicationUrl(pds, publicationUri).catch(() => null)
-    const url = pubDomain ? `${pubDomain.replace(/\/$/, "")}/${rkey}` : fallbackUrl
+    const url = pubDomain ? `${pubDomain.replace(/\/$/, "")}/${slug}` : fallbackUrl
     return {
       success: true,
       uri: result.uri,

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -18,6 +18,7 @@
  */
 
 import { readFileSync, existsSync } from "node:fs"
+import { resolve as pathResolve, dirname } from "node:path"
 import { loadConfig, loadCredentials } from "../config.js"
 
 interface PublishOptions {
@@ -40,9 +41,25 @@ interface FrontmatterFields {
   rkey?: string
 }
 
+interface LeafletByteSlice {
+  byteStart: number
+  byteEnd: number
+}
+
+interface LeafletLinkFeature {
+  $type: "pub.leaflet.richtext.facet#link"
+  uri: string
+}
+
+interface LeafletFacet {
+  index: LeafletByteSlice
+  features: LeafletLinkFeature[]
+}
+
 interface LeafletTextBlock {
   $type: "pub.leaflet.blocks.text"
   plaintext: string
+  facets?: LeafletFacet[]
   textSize?: "default" | "small" | "large"
 }
 
@@ -50,9 +67,25 @@ interface LeafletHeaderBlock {
   $type: "pub.leaflet.blocks.header"
   level: number
   plaintext: string
+  facets?: LeafletFacet[]
 }
 
-type LeafletBlock = LeafletTextBlock | LeafletHeaderBlock
+interface BlobRef {
+  $type: "blob"
+  ref: { $link: string }
+  mimeType: string
+  size: number
+}
+
+interface LeafletImageBlock {
+  $type: "pub.leaflet.blocks.image"
+  image: BlobRef
+  aspectRatio: { width: number; height: number }
+  alt?: string
+  fullBleed?: boolean
+}
+
+type LeafletBlock = LeafletTextBlock | LeafletHeaderBlock | LeafletImageBlock
 
 interface LeafletPageBlock {
   $type: "pub.leaflet.pages.linearDocument#block"
@@ -143,6 +176,15 @@ function slugify(title: string): string {
  * features. See reference/sensemaker/followups/social-cli-publish.md.
  */
 function stripMarkdown(text: string): string {
+  return stripMarkdownInline(text).trim()
+}
+
+/**
+ * Same as stripMarkdown but preserves leading/trailing whitespace.
+ * Used by parseInlineWithFacets so concatenating chunks around facet spans
+ * doesn't lose the spaces between them.
+ */
+function stripMarkdownInline(text: string): string {
   return text
     // links: [text](url) → text
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
@@ -156,46 +198,242 @@ function stripMarkdown(text: string): string {
     .replace(/<((?:https?|mailto):[^>]+)>/g, "$1")
     // escaped chars: \* → *, \_ → _, etc.
     .replace(/\\([\\`*_{}[\]()#+\-.!])/g, "$1")
-    .trim()
+}
+
+/**
+ * Inline markdown link parser. Walks `[text](url)` patterns, replaces them
+ * with just the visible text, and emits a parallel array of richtext facets
+ * with UTF-8 byte offsets for each link span. Other markdown formatting
+ * (bold, italic, code) is stripped to plaintext for now.
+ *
+ * Returns `{ plaintext, facets }`. `facets` is empty if no links are found.
+ *
+ * UTF-8 byte offset note: Leaflet (and bsky) facets use byte offsets into
+ * the UTF-8-encoded plaintext, NOT character/code-point offsets. We use
+ * TextEncoder to get the byte length of each chunk as we build the output.
+ */
+function parseInlineWithFacets(input: string): {
+  plaintext: string
+  facets: LeafletFacet[]
+} {
+  const linkRe = /\[([^\]]+)\]\(([^)]+)\)/g
+  const encoder = new TextEncoder()
+  let plaintext = ""
+  let byteOffset = 0
+  let lastEnd = 0
+  const facets: LeafletFacet[] = []
+  let m: RegExpExecArray | null
+  while ((m = linkRe.exec(input)) !== null) {
+    const between = input.slice(lastEnd, m.index)
+    const stripped = stripMarkdownInline(between)
+    plaintext += stripped
+    byteOffset += encoder.encode(stripped).length
+
+    const linkText = stripMarkdownInline(m[1])
+    const linkUri = m[2]
+    const startByte = byteOffset
+    plaintext += linkText
+    const endByte = startByte + encoder.encode(linkText).length
+    byteOffset = endByte
+
+    facets.push({
+      index: { byteStart: startByte, byteEnd: endByte },
+      features: [{ $type: "pub.leaflet.richtext.facet#link", uri: linkUri }],
+    })
+    lastEnd = m.index + m[0].length
+  }
+  // Trailing text after last match. Caller is expected to have trimmed the
+  // input already, so internal whitespace is preserved verbatim.
+  const tail = stripMarkdownInline(input.slice(lastEnd))
+  plaintext += tail
+  return { plaintext, facets }
+}
+
+/**
+ * Read PNG/JPEG/WebP image headers to extract width, height, and mimeType.
+ * Throws if the format isn't recognized. Supports the common cases without
+ * pulling in a dependency.
+ */
+function getImageInfo(data: Buffer): {
+  width: number
+  height: number
+  mime: string
+} {
+  // PNG: 8-byte signature, then IHDR chunk at bytes 8-23 (width @ 16, height @ 20)
+  if (
+    data[0] === 0x89 &&
+    data[1] === 0x50 &&
+    data[2] === 0x4e &&
+    data[3] === 0x47
+  ) {
+    return {
+      width: data.readUInt32BE(16),
+      height: data.readUInt32BE(20),
+      mime: "image/png",
+    }
+  }
+  // JPEG: starts FFD8, scan for SOFn marker (FFC0..FFCF except DHT/DAC/DRI)
+  if (data[0] === 0xff && data[1] === 0xd8) {
+    let i = 2
+    while (i < data.length - 8) {
+      if (data[i] !== 0xff) {
+        i++
+        continue
+      }
+      const marker = data[i + 1]
+      const isSOF =
+        (marker >= 0xc0 && marker <= 0xc3) ||
+        (marker >= 0xc5 && marker <= 0xc7) ||
+        (marker >= 0xc9 && marker <= 0xcb) ||
+        (marker >= 0xcd && marker <= 0xcf)
+      if (isSOF) {
+        return {
+          height: data.readUInt16BE(i + 5),
+          width: data.readUInt16BE(i + 7),
+          mime: "image/jpeg",
+        }
+      }
+      // Skip this segment
+      const segLen = data.readUInt16BE(i + 2)
+      i += 2 + segLen
+    }
+  }
+  // WebP: "RIFF....WEBP" header, then VP8 / VP8L / VP8X chunk
+  if (
+    data[0] === 0x52 &&
+    data[1] === 0x49 &&
+    data[2] === 0x46 &&
+    data[3] === 0x46 &&
+    data[8] === 0x57 &&
+    data[9] === 0x45 &&
+    data[10] === 0x42 &&
+    data[11] === 0x50
+  ) {
+    const subtype = data.toString("ascii", 12, 16)
+    if (subtype === "VP8X") {
+      const width = (data[24] | (data[25] << 8) | (data[26] << 16)) + 1
+      const height = (data[27] | (data[28] << 8) | (data[29] << 16)) + 1
+      return { width, height, mime: "image/webp" }
+    }
+    if (subtype === "VP8L") {
+      const b0 = data[21]
+      const b1 = data[22]
+      const b2 = data[23]
+      const b3 = data[24]
+      const width = (((b1 & 0x3f) << 8) | b0) + 1
+      const height = (((b3 & 0x0f) << 10) | (b2 << 2) | ((b1 & 0xc0) >> 6)) + 1
+      return { width, height, mime: "image/webp" }
+    }
+    if (subtype === "VP8 ") {
+      const width = data.readUInt16LE(26) & 0x3fff
+      const height = data.readUInt16LE(28) & 0x3fff
+      return { width, height, mime: "image/webp" }
+    }
+  }
+  throw new Error("Unsupported image format (only PNG, JPEG, WebP)")
+}
+
+/**
+ * Upload a blob to the agent's PDS via com.atproto.repo.uploadBlob.
+ * Returns the BlobRef that can be embedded in a record.
+ */
+async function uploadBlob(
+  pds: string,
+  accessJwt: string,
+  data: Buffer,
+  mime: string
+): Promise<BlobRef> {
+  const response = await fetch(`${pds}/xrpc/com.atproto.repo.uploadBlob`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessJwt}`,
+      "Content-Type": mime,
+    },
+    body: data,
+  })
+  if (!response.ok) {
+    throw new Error(`uploadBlob failed: ${response.status} ${await response.text()}`)
+  }
+  const result = (await response.json()) as { blob: BlobRef }
+  return result.blob
 }
 
 /**
  * Convert a markdown body to an array of Leaflet page-blocks.
  *
- * MVP scope:
+ * Supports:
  * - ATX headings (`# heading`) → pub.leaflet.blocks.header
  * - Paragraphs (everything else, separated by blank lines) → pub.leaflet.blocks.text
- * - Blockquotes, lists, code blocks, images — flattened to plaintext for now
+ * - Inline links `[text](url)` → richtext facets on text/header blocks
+ * - Standalone image lines `![alt](path)` → pub.leaflet.blocks.image
+ *   (path resolved relative to `basePath`; blob uploaded to PDS)
  *
- * Each block's plaintext has markdown formatting stripped (no facets in MVP).
+ * Other markdown (bold, italic, code, lists, blockquotes, code blocks) is
+ * stripped to plaintext for now.
  */
-function markdownToBlocks(markdown: string): LeafletPageBlock[] {
+async function markdownToBlocks(
+  markdown: string,
+  opts: { pds: string; accessJwt: string; basePath: string }
+): Promise<LeafletPageBlock[]> {
   const blocks: LeafletPageBlock[] = []
   // Split on blank lines (one or more newlines with only whitespace between)
   const paragraphs = markdown.split(/\n\s*\n/).map(p => p.trim()).filter(Boolean)
 
   for (const para of paragraphs) {
+    // Standalone image: ![alt](path) — must be the entire paragraph
+    const imageMatch = para.match(/^!\[([^\]]*)\]\(([^)]+)\)$/)
+    if (imageMatch) {
+      const alt = imageMatch[1]
+      const imgRelPath = imageMatch[2]
+      const imgAbsPath = imgRelPath.startsWith("/")
+        ? imgRelPath
+        : pathResolve(opts.basePath, imgRelPath)
+      if (!existsSync(imgAbsPath)) {
+        throw new Error(`Image not found: ${imgAbsPath} (from \`${imgRelPath}\`)`)
+      }
+      const imgData = readFileSync(imgAbsPath)
+      const info = getImageInfo(imgData)
+      const blob = await uploadBlob(opts.pds, opts.accessJwt, imgData, info.mime)
+      const imageBlock: LeafletImageBlock = {
+        $type: "pub.leaflet.blocks.image",
+        image: blob,
+        aspectRatio: { width: info.width, height: info.height },
+      }
+      if (alt) imageBlock.alt = alt
+      blocks.push({
+        $type: "pub.leaflet.pages.linearDocument#block",
+        block: imageBlock,
+      })
+      continue
+    }
+
     // Heading? ATX form: 1-6 #s + space + text
     const headingMatch = para.match(/^(#{1,6})\s+(.+?)\s*#*$/)
     if (headingMatch && !para.includes("\n")) {
+      const { plaintext, facets } = parseInlineWithFacets(headingMatch[2])
+      const headerBlock: LeafletHeaderBlock = {
+        $type: "pub.leaflet.blocks.header",
+        level: headingMatch[1].length,
+        plaintext,
+      }
+      if (facets.length > 0) headerBlock.facets = facets
       blocks.push({
         $type: "pub.leaflet.pages.linearDocument#block",
-        block: {
-          $type: "pub.leaflet.blocks.header",
-          level: headingMatch[1].length,
-          plaintext: stripMarkdown(headingMatch[2]),
-        },
+        block: headerBlock,
       })
       continue
     }
     // Otherwise: text block. Collapse internal newlines to single space.
     const flat = para.replace(/\s*\n\s*/g, " ").trim()
+    const { plaintext, facets } = parseInlineWithFacets(flat)
+    const textBlock: LeafletTextBlock = {
+      $type: "pub.leaflet.blocks.text",
+      plaintext,
+    }
+    if (facets.length > 0) textBlock.facets = facets
     blocks.push({
       $type: "pub.leaflet.pages.linearDocument#block",
-      block: {
-        $type: "pub.leaflet.blocks.text",
-        plaintext: stripMarkdown(flat),
-      },
+      block: textBlock,
     })
   }
 
@@ -354,8 +592,30 @@ async function publishDocument(opts: PublishOptions): Promise<PublishResult> {
     }
   }
 
-  // Build blocks + content
-  const blocks = markdownToBlocks(body)
+  // Establish session early so we can upload image blobs while parsing.
+  // (Skipped in dry-run; image blocks would require an upload, so we error
+  // on dry-run with images for now.)
+  const session = opts.dryRun
+    ? null
+    : await createSession(pds, handle, appPassword)
+
+  // Resolve a base path for relative image references. If publishing from a
+  // file, that's the file's directory; otherwise, current working directory.
+  const basePath = opts.file ? dirname(pathResolve(opts.file)) : process.cwd()
+
+  // Build blocks + content. If the body contains image lines but we're in
+  // dry-run mode, fall back: emit a warning and skip blob upload by using a
+  // placeholder accessJwt (markdownToBlocks will throw on actual upload).
+  let blocks: LeafletPageBlock[]
+  try {
+    blocks = await markdownToBlocks(body, {
+      pds,
+      accessJwt: session?.accessJwt ?? "",
+      basePath,
+    })
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : String(e) }
+  }
   if (blocks.length === 0) {
     return { success: false, error: "No content blocks parsed from body" }
   }
@@ -397,8 +657,11 @@ async function publishDocument(opts: PublishOptions): Promise<PublishResult> {
     }
   }
 
+  // Session was created above (skipped only in dry-run, which returns earlier).
+  if (!session) {
+    return { success: false, error: "Internal error: missing session for write" }
+  }
   try {
-    const session = await createSession(pds, handle, appPassword)
     const response = await fetch(`${pds}/xrpc/com.atproto.repo.putRecord`, {
       method: "POST",
       headers: {

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -51,9 +51,27 @@ interface LeafletLinkFeature {
   uri: string
 }
 
+interface LeafletBoldFeature {
+  $type: "pub.leaflet.richtext.facet#bold"
+}
+
+interface LeafletItalicFeature {
+  $type: "pub.leaflet.richtext.facet#italic"
+}
+
+interface LeafletCodeFeature {
+  $type: "pub.leaflet.richtext.facet#code"
+}
+
+type LeafletFeature =
+  | LeafletLinkFeature
+  | LeafletBoldFeature
+  | LeafletItalicFeature
+  | LeafletCodeFeature
+
 interface LeafletFacet {
   index: LeafletByteSlice
-  features: LeafletLinkFeature[]
+  features: LeafletFeature[]
 }
 
 interface LeafletTextBlock {
@@ -185,9 +203,17 @@ function stripMarkdown(text: string): string {
  * doesn't lose the spaces between them.
  */
 function stripMarkdownInline(text: string): string {
+  return stripMarkdownNonLinks(text).replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+}
+
+/**
+ * Strip everything stripMarkdownInline strips EXCEPT link syntax. Used as a
+ * preprocessing pass in parseInlineWithFacets so bold/italic/code spans that
+ * surround a link (e.g. `**[text](url).**`) get unwrapped before the link
+ * walker runs — otherwise the markers end up in plaintext as literal `**`.
+ */
+function stripMarkdownNonLinks(text: string): string {
   return text
-    // links: [text](url) → text
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
     // bold: **text** or __text__
     .replace(/(\*\*|__)(.+?)\1/g, "$2")
     // italic: *text* or _text_ (avoid matching inside words)
@@ -216,36 +242,80 @@ function parseInlineWithFacets(input: string): {
   plaintext: string
   facets: LeafletFacet[]
 } {
-  const linkRe = /\[([^\]]+)\]\(([^)]+)\)/g
   const encoder = new TextEncoder()
+  // First normalize escapes and autolinks — neither generates a facet,
+  // they're just transformations on the visible text.
+  const normalized = input
+    .replace(/<((?:https?|mailto):[^>]+)>/g, "$1")
+    .replace(/\\([\\`*_{}[\]()#+\-.!])/g, "$1")
+
+  // Token order matters. Patterns are tried in this priority:
+  //  1. `**[text](url)**`  — bold + link (both facets at the same span)
+  //  2. `**text**` / `__text__` — bold
+  //  3. `[text](url)` — link
+  //  4. `*text*` / `_text_` — italic (must be tried after bold so we don't
+  //     eat a `**` as two italics; word-boundary lookaround prevents matching
+  //     emphasis inside identifiers)
+  //  5. `` `text` `` — inline code
+  //  6. plain text (anything else, one chunk at a time)
+  const tokenRe = new RegExp(
+    [
+      "\\*\\*\\[([^\\]]+)\\]\\(([^)]+)\\)\\*\\*", // 1,2: boldLinkText, boldLinkUri
+      "\\*\\*([^*]+?)\\*\\*|__([^_]+?)__", // 3,4: bold (asterisk or underscore)
+      "\\[([^\\]]+)\\]\\(([^)]+)\\)", // 5,6: linkText, linkUri
+      "(?<![\\w*])\\*([^*\\n]+?)\\*(?![\\w*])|(?<![\\w_])_([^_\\n]+?)_(?![\\w_])", // 7,8: italic
+      "`([^`]+?)`", // 9: code
+      "[\\s\\S]", // 10: any single char (plain text fallback)
+    ].join("|"),
+    "g",
+  )
+
   let plaintext = ""
   let byteOffset = 0
-  let lastEnd = 0
   const facets: LeafletFacet[] = []
   let m: RegExpExecArray | null
-  while ((m = linkRe.exec(input)) !== null) {
-    const between = input.slice(lastEnd, m.index)
-    const stripped = stripMarkdownInline(between)
-    plaintext += stripped
-    byteOffset += encoder.encode(stripped).length
+  let plainBuffer = ""
 
-    const linkText = stripMarkdownInline(m[1])
-    const linkUri = m[2]
-    const startByte = byteOffset
-    plaintext += linkText
-    const endByte = startByte + encoder.encode(linkText).length
-    byteOffset = endByte
-
-    facets.push({
-      index: { byteStart: startByte, byteEnd: endByte },
-      features: [{ $type: "pub.leaflet.richtext.facet#link", uri: linkUri }],
-    })
-    lastEnd = m.index + m[0].length
+  const flushPlain = () => {
+    if (plainBuffer) {
+      plaintext += plainBuffer
+      byteOffset += encoder.encode(plainBuffer).length
+      plainBuffer = ""
+    }
   }
-  // Trailing text after last match. Caller is expected to have trimmed the
-  // input already, so internal whitespace is preserved verbatim.
-  const tail = stripMarkdownInline(input.slice(lastEnd))
-  plaintext += tail
+
+  const emitSpan = (text: string, features: LeafletFacet["features"]) => {
+    flushPlain()
+    const startByte = byteOffset
+    plaintext += text
+    const endByte = startByte + encoder.encode(text).length
+    byteOffset = endByte
+    facets.push({ index: { byteStart: startByte, byteEnd: endByte }, features })
+  }
+
+  while ((m = tokenRe.exec(normalized)) !== null) {
+    if (m[1] !== undefined) {
+      // bold + link
+      emitSpan(m[1], [
+        { $type: "pub.leaflet.richtext.facet#bold" },
+        { $type: "pub.leaflet.richtext.facet#link", uri: m[2] },
+      ])
+    } else if (m[3] !== undefined || m[4] !== undefined) {
+      emitSpan(m[3] ?? m[4], [{ $type: "pub.leaflet.richtext.facet#bold" }])
+    } else if (m[5] !== undefined) {
+      emitSpan(m[5], [
+        { $type: "pub.leaflet.richtext.facet#link", uri: m[6] },
+      ])
+    } else if (m[7] !== undefined || m[8] !== undefined) {
+      emitSpan(m[7] ?? m[8], [{ $type: "pub.leaflet.richtext.facet#italic" }])
+    } else if (m[9] !== undefined) {
+      emitSpan(m[9], [{ $type: "pub.leaflet.richtext.facet#code" }])
+    } else {
+      // Plain char — buffer to coalesce runs
+      plainBuffer += m[0]
+    }
+  }
+  flushPlain()
   return { plaintext, facets }
 }
 

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -93,14 +93,6 @@ interface PublishResult {
   error?: string
 }
 
-// sensemaker's Leaflet publication. The site.standard.publication record holds
-// the metadata Leaflet's appview reads (title, description, theme). The
-// matching pub.leaflet.publication record (created via Leaflet's UI) holds
-// the leaflet-native config (subdomain, preferences). Documents reference
-// the site.standard.publication via the `site` field.
-const DEFAULT_PUBLICATION_URI =
-  "at://did:plc:4j7exarb62djxycrgdfhuulr/site.standard.publication/3ml7tpkenes2j"
-const DEFAULT_PUBLICATION_DOMAIN = "https://sensemaker.leaflet.pub"
 const TID_LAST_TIMESTAMP = { value: 0 }
 
 /**
@@ -267,6 +259,26 @@ function extractFrontmatter(content: string): { frontmatter: FrontmatterFields; 
   return { frontmatter, body }
 }
 
+/**
+ * Fetch a site.standard.publication record and return its `url` field, if any.
+ * Used to construct rendered document URLs that match the publisher's chosen
+ * domain (e.g. sensemaker.leaflet.pub) rather than the deep permalink.
+ *
+ * Parses an at-uri of the form at://{did}/{collection}/{rkey} and calls
+ * com.atproto.repo.getRecord on the appropriate PDS. Returns null on any
+ * error so callers can fall back to the deep permalink.
+ */
+async function fetchPublicationUrl(pds: string, publicationUri: string): Promise<string | null> {
+  const match = publicationUri.match(/^at:\/\/([^/]+)\/([^/]+)\/([^/]+)$/)
+  if (!match) return null
+  const [, repo, collection, rkey] = match
+  const params = new URLSearchParams({ repo, collection, rkey })
+  const response = await fetch(`${pds}/xrpc/com.atproto.repo.getRecord?${params}`)
+  if (!response.ok) return null
+  const data = (await response.json()) as { value?: { url?: string } }
+  return data.value?.url ?? null
+}
+
 async function createSession(
   pds: string,
   handle: string,
@@ -332,7 +344,15 @@ async function publishDocument(opts: PublishOptions): Promise<PublishResult> {
   // Defaults
   if (!slug) slug = slugify(title)
   if (!rkey) rkey = generateTid()
-  const publicationUri = opts.publication ?? process.env.PUBLICATION_URI ?? DEFAULT_PUBLICATION_URI
+  const publicationUri = opts.publication ?? process.env.LEAFLET_PUBLICATION_URI
+  if (!publicationUri) {
+    return {
+      success: false,
+      error:
+        "No publication specified. Pass --publication <at-uri> or set LEAFLET_PUBLICATION_URI env var. " +
+        "Create a publication at https://leaflet.pub/new and find its AT-URI in your PDS.",
+    }
+  }
 
   // Build blocks + content
   const blocks = markdownToBlocks(body)
@@ -401,14 +421,15 @@ async function publishDocument(opts: PublishOptions): Promise<PublishResult> {
     }
 
     const result = (await response.json()) as { uri: string; cid: string }
-    // Construct rendered URL. Prefer the publication's clean subdomain when
-    // we're publishing to sensemaker's default pub; otherwise fall back to
-    // the deep /lish/{did}/{pub-rkey}/{doc-rkey} permalink.
+    // Construct rendered URL. Prefer the publication's own `url` field
+    // (typically a Leaflet subdomain like sensemaker.leaflet.pub or a
+    // custom domain) so the link points at the publisher's chosen home.
+    // Fall back to the deep /lish/{did}/{pub-rkey}/{doc-rkey} permalink
+    // if the publication record doesn't expose a URL or can't be fetched.
     const pubRkey = publicationUri.split("/").pop() ?? ""
-    const url =
-      publicationUri === DEFAULT_PUBLICATION_URI
-        ? `${DEFAULT_PUBLICATION_DOMAIN}/${rkey}`
-        : `https://leaflet.pub/lish/${session.did}/${pubRkey}/${rkey}`
+    const fallbackUrl = `https://leaflet.pub/lish/${session.did}/${pubRkey}/${rkey}`
+    const pubDomain = await fetchPublicationUrl(pds, publicationUri).catch(() => null)
+    const url = pubDomain ? `${pubDomain.replace(/\/$/, "")}/${rkey}` : fallbackUrl
     return {
       success: true,
       uri: result.uri,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**", "**/.letta/**"],
+  },
+})


### PR DESCRIPTION
## Summary

Adds \`social-cli publish\` for writing long-form documents to ATProto via the standard.site + Leaflet lexicon set. Documents render on Leaflet's appview at \`leaflet.pub/lish/{did}/{pub-rkey}/{doc-rkey}\`.

This pivoted from an Offprint-targeted MVP — Offprint binds rendering to dashboard entities, so externally-authored PDS records weren't picked up. Posted to @leaflet.pub asking the same question; Jared Pereira (top Leaflet contributor) confirmed the appview renders externally-authored records as long as they include the proper \`pub.leaflet.*\` types.

## What it does

- \`social-cli publish -f essay.md\` writes a \`site.standard.document\` with embedded \`pub.leaflet.content\` to the agent's PDS
- Markdown is parsed into \`pub.leaflet.blocks.text\` (paragraphs) and \`pub.leaflet.blocks.header\` (ATX headings 1-6)
- Frontmatter (title, description, tags, slug, rkey) supported in markdown files
- \`--dry-run\` prints the full record JSON without writing
- \`--rkey\` allows updating an existing document
- Output URL points to Leaflet's actual route pattern

## Schema notes

Documented in \`src/commands/publish.ts\` header. Two non-obvious gotchas:

1. Each block in \`pages[].blocks\` MUST have \`\$type: \"pub.leaflet.pages.linearDocument#block\"\` at the wrapper level, even though it's a sibling-def ref in the same lexicon. Without it, the appview returns 404.
2. The \`pub.leaflet.publication\` and \`site.standard.publication\` records are cross-referenced by matching rkey. Documents reference the \`site.standard.publication\` via the \`site\` field.

## Limitations (followups)

- Markdown formatting (\`**bold**\`, \`*italic*\`, \`[links](url)\`, \`\` \`code\` \`\`) is currently stripped to plaintext. Should become \`pub.leaflet.richtext.facet\` features.
- Block types beyond text/header (lists, blockquotes, code blocks, images, iframes, math, horizontal rules, embedded Bluesky posts) are not yet supported. Markdown for these is flattened to paragraphs.
- No image/blob upload support yet.
- No multi-page document support — current implementation writes a single \`pub.leaflet.pages.linearDocument\` per doc.

## Test plan

- [x] \`publish --dry-run\` produces valid record JSON
- [x] Published smoke-test doc renders correctly on \`leaflet.pub/lish/{did}/{pub-rkey}/{doc-rkey}\`
- [x] Title, description, headings, paragraphs all render
- [x] Author byline + publication card show up correctly
- [x] Cleaned up smoke-test docs after verification

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>