### PR TITLE
Keep runtime state out of repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,12 @@ package-lock.json
 outbox_archive/
 sent_ledger.yaml
 attachments/
+# Generated social-cli runtime state
+.social-cli/state/
+inbox*.yaml
+outbox*.yaml
+processed*.yaml
+sent_ledger*.yaml
+dispatch_result*.yaml
+*_feed.yaml
+*_inbox.yaml

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -26,18 +26,52 @@ In the X developer portal, these map to the **OAuth 1.0 Keys** section:
 
 If a command fails with an auth error, tell your operator.
 
+
+## Runtime State: read this first
+
+Generated runtime files live under a state directory, not necessarily the repo root. Before reading or writing inbox/outbox files, run:
+
+```bash
+social-cli doctor
+```
+
+Use the printed `stateDir`. The normal files are:
+
+- `inbox-bsky.yaml`, `inbox-x.yaml` — pending notifications
+- `outbox-bsky.yaml`, `outbox-x.yaml` — your dispatch decisions
+- `dispatch_result-bsky.yaml`, `dispatch_result-x.yaml` — results
+- `processed-*.yaml`, `sent_ledger-*.yaml`, `outbox_archive/` — bookkeeping
+
+Default state directory:
+
+- If `AGENT_ID` is set: `.social-cli/state/agents/<AGENT_ID>/`
+- Otherwise: `.social-cli/state/`
+
+If multiple non-Letta agents share a checkout, set `SOCIAL_CLI_STATE_DIR` or `state.stateDir` in `config.yaml` so they do not share inboxes and ledgers.
+
+If `doctor` reports root-level runtime files, run:
+
+```bash
+social-cli doctor --migrate
+```
+
+This moves legacy generated files into the active state directory without overwriting existing files.
+
 ## Core Loop
 
 Your primary workflow is a three-step loop:
 
 ```bash
+# 0. Locate runtime state
+social-cli doctor
+
 # 1. Pull notifications
 social-cli sync --users-dir /path/to/your/users/
 
 # 2. Check if anything needs attention
 social-cli check || exit 0
 
-# 3. Read inbox.yaml, decide what to do, write outbox.yaml, then:
+# 3. Read stateDir/inbox-{platform}.yaml, decide what to do, write stateDir/outbox-{platform}.yaml, then:
 social-cli dispatch
 ```
 
@@ -47,9 +81,9 @@ social-cli dispatch
 social-cli sync --platform bsky --platform x --users-dir /path/to/users/
 ```
 
-This writes `inbox.yaml` as a local pending-work queue. Sync merges in unseen notifications and leaves existing pending items in place until they are explicitly handled by dispatch. It is not an append-only history log. If `--users-dir` is provided, each notification is enriched with a `userContext` field containing your memory file for that author (if one exists). Use this context to personalize your responses.
+This writes `inbox-{platform}.yaml` under the active state directory as a local pending-work queue. Sync merges in unseen notifications and leaves existing pending items in place until they are explicitly handled by dispatch. It is not an append-only history log. If `--users-dir` is provided, each notification is enriched with a `userContext` field containing your memory file for that author (if one exists). Use this context to personalize your responses.
 
-**Output format** (`inbox.yaml`):
+**Output format** (`stateDir/inbox-{platform}.yaml`):
 ```yaml
 notifications:
   - id: "at://did:plc:xxx/app.bsky.feed.post/abc"
@@ -80,7 +114,7 @@ Options:
 - `--users-dir <path>` — directory of user `.md` files for context enrichment
 - `-n, --limit <number>` — max notifications per platform (default: 50)
 - `--max-items <number>` — cap total inbox size (default: 200, oldest dropped)
-- `-o, --output <file>` — output file (default: `inbox.yaml`)
+- `-o, --output <file>` — legacy shared output file when platform isolation is disabled
 
 ### Step 2: Check
 
@@ -99,7 +133,7 @@ No stdout. Decision is purely in the exit code.
 
 ### Step 3: Decide and Dispatch
 
-Read `inbox.yaml`, decide what to do, and write `outbox.yaml`:
+Read `stateDir/inbox-{platform}.yaml`, decide what to do, and write `stateDir/outbox-{platform}.yaml`:
 
 ```yaml
 dispatch:
@@ -156,14 +190,14 @@ social-cli dispatch
 **What happens:**
 1. Validates all actions (char limits, required fields, platform support).
 2. Executes each action. Continues on failure — one bad action doesn't block the rest.
-3. Writes `dispatch_result.yaml` with per-action results.
-4. Archives `outbox.yaml` to `outbox_archive/`.
-5. Removes processed notifications from `inbox.yaml`, keeping the file aligned to pending work only.
+3. Writes `dispatch_result-{platform}.yaml` with per-action results.
+4. Archives `outbox-{platform}.yaml` to `outbox_archive/`.
+5. Removes processed notifications from `inbox-{platform}.yaml`, keeping the file aligned to pending work only.
 
 **Exit codes:**
 - 0 = all actions succeeded
 - 1 = validation failed (nothing was dispatched)
-- 2 = partial failure (some actions failed, check `dispatch_result.yaml`)
+- 2 = partial failure (some actions failed, check `dispatch_result-{platform}.yaml`)
 
 **Dry run** — validate without posting:
 ```bash
@@ -294,18 +328,18 @@ Name your files by ID for stability (handles change), or by handle for readabili
 
 - All API calls retry 3 times with exponential backoff on transient errors (429, 5xx, network failures).
 - Bluesky sessions auto-refresh on token expiry.
-- Dispatch continues through failures — check `dispatch_result.yaml` for what succeeded.
-- If a thread fails mid-chain, `dispatch_result.yaml` includes `resumeFrom` with the index and remaining posts so you can retry from where it stopped.
+- Dispatch continues through failures — check `dispatch_result-{platform}.yaml` for what succeeded.
+- If a thread fails mid-chain, `dispatch_result-{platform}.yaml` includes `resumeFrom` with the index and remaining posts so you can retry from where it stopped.
 
 ## Critical: Dispatch vs Quick Commands
 
 There are two ways to post: the **dispatch pipeline** and **quick commands**. They are not interchangeable.
 
-**Always use dispatch when replying to inbox notifications.** The dispatch pipeline marks notifications as processed and removes them from `inbox.yaml`. Quick commands (`reply`, `post`) do not. If you use `reply` directly on an inbox item, the notification stays in the inbox and will reappear next sync — you'll waste time re-investigating something you already handled.
+**Always use dispatch when replying to inbox notifications.** The dispatch pipeline marks notifications as processed and removes them from `inbox-{platform}.yaml`. Quick commands (`reply`, `post`) do not. If you use `reply` directly on an inbox item, the notification stays in the inbox and will reappear next sync — you'll waste time re-investigating something you already handled.
 
 ```
 # CORRECT — replying to a notification
-# Write outbox.yaml with a reply action, then:
+# Write stateDir/outbox-{platform}.yaml with a reply action, then:
 social-cli dispatch
 
 # WRONG — replying to a notification
@@ -333,9 +367,9 @@ When processing inbox notifications:
 
 | Command | Description | Output |
 |---------|-------------|--------|
-| `sync` | Pull notifications | `inbox.yaml` |
+| `sync` | Pull notifications | `stateDir/inbox-{platform}.yaml` |
 | `check` | Anything actionable? | exit code only |
-| `dispatch` | Execute outbox | `dispatch_result.yaml` |
+| `dispatch` | Execute outbox | `stateDir/dispatch_result-{platform}.yaml` |
 | `post` | Single post | stdout (post ID) |
 | `reply` | Reply to post | stdout (post ID) |
 | `thread` | Post thread | stdout (post IDs) |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,43 @@ LEAFLET_PUBLICATION_URI=at://did:plc:.../site.standard.publication/...
 
 Optional dispatch hooks are also configured in `config.yaml`; see [Dispatch hooks](#dispatch-hooks).
 
+
+## Runtime state
+
+`social-cli` writes generated runtime state under a gitignored state directory, not the repo root. By default:
+
+- Letta agents (`AGENT_ID` set): `.social-cli/state/agents/<AGENT_ID>/`
+- Other users/agents: `.social-cli/state/`
+
+Override this with either:
+
+```bash
+SOCIAL_CLI_STATE_DIR=/path/to/state
+```
+
+or in `config.yaml`:
+
+```yaml
+state:
+  stateDir: /path/to/state
+```
+
+Use an explicit state directory when multiple non-Letta agents share the same checkout. Otherwise they will share `.social-cli/state/`.
+
+Generated files include `inbox-{platform}.yaml`, `outbox-{platform}.yaml`, `processed-{platform}.yaml`, `sent_ledger-{platform}.yaml`, `dispatch_result-{platform}.yaml`, and `outbox_archive/`. Run:
+
+```bash
+social-cli doctor
+```
+
+to see the active state directory and detect old root-level runtime files. Run:
+
+```bash
+social-cli doctor --migrate
+```
+
+to move legacy root-level runtime files into the active state directory. Existing destination files are not overwritten.
+
 ## How it works
 
 social-cli has two modes: an **agent loop** for automated notification handling, and **quick commands** for direct actions.
@@ -68,13 +105,14 @@ social-cli has two modes: an **agent loop** for automated notification handling,
 ### Agent loop
 
 ```bash
-social-cli sync -p bsky -p x          # pull notifications → inbox.yaml
+social-cli doctor                       # shows active state directory
+social-cli sync -p bsky -p x          # pull notifications → stateDir/inbox-{platform}.yaml
 social-cli check || exit 0            # anything actionable? no → bail
-# agent reads inbox.yaml, decides, writes outbox.yaml
+# agent reads stateDir/inbox-{platform}.yaml, decides, writes stateDir/outbox-{platform}.yaml
 social-cli dispatch                    # execute decisions, mark processed
 ```
 
-The agent loop handles bookkeeping — marking notifications as processed, deduplicating, archiving outboxes. Agents read `inbox.yaml`, write decisions to `outbox.yaml`, and `dispatch` executes them.
+The agent loop handles bookkeeping — marking notifications as processed, deduplicating, archiving outboxes. Agents read `inbox-{platform}.yaml`, write decisions to `outbox-{platform}.yaml`, and `dispatch` executes them. These files live under the active state directory shown by `social-cli doctor`.
 
 ### Quick commands
 
@@ -111,7 +149,7 @@ All read commands output YAML to stdout (except `feed` which defaults to a file)
 
 ## Outbox format
 
-Agents write decisions to `outbox.yaml` for dispatch:
+Agents write decisions to `outbox-{platform}.yaml` in the active state directory for dispatch:
 
 ```yaml
 dispatch:
@@ -342,7 +380,7 @@ Bundled agent-facing guidance and workflows under `skills/`:
 - **Atomic writes**: All YAML output uses tmp+rename. No half-written files on crash.
 - **Char validation**: Quick commands reject oversized text before hitting the API.
 - **Inbox cap**: `--max-items` (default 200) truncates oldest entries to prevent unbounded growth.
-- **Thread resume**: If a thread fails mid-chain, `dispatch_result.yaml` includes `resumeFrom` with the index and remaining posts.
+- **Thread resume**: If a thread fails mid-chain, `dispatch_result-{platform}.yaml` includes `resumeFrom` with the index and remaining posts.
 - **Continue-on-failure**: Dispatch processes all actions even if some fail. Exit code 2 on partial failure.
 - **Replay detection**: Dispatch prevents posting the same reply twice to the same target.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,9 +72,10 @@ program
 program
   .command("doctor")
   .description("Check social-cli runtime state and local hygiene")
-  .action(async () => {
+  .option("--migrate", "Move legacy root-level runtime files into the state directory")
+  .action(async (opts) => {
     const { doctor } = await import("./commands/doctor.js")
-    await doctor()
+    await doctor({ migrate: opts.migrate })
   })
 
 // check: Anything actionable? Exit code only.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,14 +20,14 @@ const program = new Command()
   .description("Agent-optimized social media CLI")
   .version("0.1.0")
 
-// sync: Fetch notifications → inbox.yaml
+// sync: Fetch notifications → stateDir/inbox-{platform}.yaml
 program
   .command("sync")
-  .description("Fetch notifications from platforms → inbox.yaml")
+  .description("Fetch notifications from platforms → stateDir/inbox-{platform}.yaml")
   .option("-p, --platform <platforms...>", "Platforms to sync (default: all)")
   .option("--unread-only", "Only fetch unread notifications", true)
   .option("-n, --limit <number>", "Max notifications per platform", "50")
-  .option("-o, --output <file>", "Output file", "inbox.yaml")
+  .option("-o, --output <file>", "Legacy shared output file", "inbox.yaml")
   .option("--max-items <number>", "Max inbox items before truncating oldest", "200")
   .option("--users-dir <path>", "Directory of user memory files for context enrichment")
   .option("--auto-create-users", "Create missing user memory files during sync")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -68,6 +68,15 @@ program
     await dispatch({ file, dryRun: opts.dryRun, platform: opts.platform })
   })
 
+// doctor: Check local runtime-state hygiene
+program
+  .command("doctor")
+  .description("Check social-cli runtime state and local hygiene")
+  .action(async () => {
+    const { doctor } = await import("./commands/doctor.js")
+    await doctor()
+  })
+
 // check: Anything actionable? Exit code only.
 program
   .command("check")

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -34,6 +34,7 @@ import {
   writePlatformFile,
   readSharedFile,
   resolveStateDir,
+  rootRuntimeWarning,
 } from "../lib/state.js"
 
 /**
@@ -231,6 +232,8 @@ async function dispatchPlatform(
   const platformIsolation = config.state?.platformIsolation ?? true
   const stateDir = config.state?.stateDir
   const allowedPlatforms = config.dispatch?.allowedPlatforms
+  const runtimeWarning = rootRuntimeWarning(stateDir)
+  if (runtimeWarning) console.warn(runtimeWarning)
 
   // Validate platform is in allowed set
   if (allowedPlatforms && allowedPlatforms.length > 0) {

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -33,6 +33,7 @@ import {
   readPlatformFile,
   writePlatformFile,
   readSharedFile,
+  resolveStateDir,
 } from "../lib/state.js"
 
 /**
@@ -816,7 +817,7 @@ async function dispatchPlatform(
   }
 
   // Archive outbox
-  const archiveDir = resolve(process.cwd(), "outbox_archive")
+  const archiveDir = resolve(resolveStateDir(stateDir), "outbox_archive")
   mkdirSync(archiveDir, { recursive: true })
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
   const archivedOutbox = join(archiveDir, `${timestamp}_outbox-${platform}.yaml`)
@@ -872,7 +873,7 @@ async function dispatchPlatform(
   }
 
   // Write results
-  const resultPath = resolve(process.cwd(), `dispatch_result-${platform}.yaml`)
+  const resultPath = getPlatformFilePath("dispatch_result", platform, stateDir)
   writeFileAtomic(resultPath, stringify({ results, archivedOutbox, inboxIdsRemoved, provenance }, { lineWidth: 120 }))
 
   // Persist processed set for future cycles

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "../config.js"
-import { findRootRuntimeFiles, migrateRootRuntimeFiles, resolveStateDir } from "../lib/state.js"
+import { defaultStateId, findRootRuntimeFiles, migrateRootRuntimeFiles, resolveStateDir } from "../lib/state.js"
 
 export async function doctor(opts: { migrate?: boolean } = {}): Promise<void> {
   const config = loadConfig()
@@ -8,6 +8,10 @@ export async function doctor(opts: { migrate?: boolean } = {}): Promise<void> {
 
   console.log("social-cli doctor")
   console.log(`stateDir: ${stateDir}`)
+  if (!configuredStateDir) {
+    console.log(`stateId: ${defaultStateId()}`)
+    console.log("Set SOCIAL_CLI_STATE_ID (or state.stateDir) to isolate multiple agents sharing one checkout.")
+  }
 
   if (opts.migrate) {
     const migrated = migrateRootRuntimeFiles(process.cwd(), configuredStateDir)
@@ -31,7 +35,7 @@ export async function doctor(opts: { migrate?: boolean } = {}): Promise<void> {
       console.log(`  - ${file}`)
     }
     console.log("")
-    console.log("These files are generated state. New sync/dispatch output goes under .social-cli/state/ by default.")
+    console.log("These files are generated state. New sync/dispatch output goes under .social-cli/state/<state-id>/ by default.")
     console.log("Run `social-cli doctor --migrate` to move root-level runtime files into the state directory.")
     console.log("Files are not overwritten if a destination already exists; inspect remaining files manually.")
   }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "../config.js"
-import { defaultStateId, findRootRuntimeFiles, migrateRootRuntimeFiles, resolveStateDir } from "../lib/state.js"
+import { findRootRuntimeFiles, migrateRootRuntimeFiles, resolveStateDir } from "../lib/state.js"
 
 export async function doctor(opts: { migrate?: boolean } = {}): Promise<void> {
   const config = loadConfig()
@@ -8,9 +8,9 @@ export async function doctor(opts: { migrate?: boolean } = {}): Promise<void> {
 
   console.log("social-cli doctor")
   console.log(`stateDir: ${stateDir}`)
-  if (!configuredStateDir) {
-    console.log(`stateId: ${defaultStateId()}`)
-    console.log("Set SOCIAL_CLI_STATE_ID (or state.stateDir) to isolate multiple agents sharing one checkout.")
+  if (!configuredStateDir && !process.env.SOCIAL_CLI_STATE_DIR && !process.env.AGENT_ID) {
+    console.log("state scope: shared checkout state")
+    console.log("Set SOCIAL_CLI_STATE_DIR or config state.stateDir to isolate multiple agents sharing one checkout.")
   }
 
   if (opts.migrate) {
@@ -35,7 +35,7 @@ export async function doctor(opts: { migrate?: boolean } = {}): Promise<void> {
       console.log(`  - ${file}`)
     }
     console.log("")
-    console.log("These files are generated state. New sync/dispatch output goes under .social-cli/state/<state-id>/ by default.")
+    console.log("These files are generated state. New sync/dispatch output goes under the configured state directory.")
     console.log("Run `social-cli doctor --migrate` to move root-level runtime files into the state directory.")
     console.log("Files are not overwritten if a destination already exists; inspect remaining files manually.")
   }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,23 @@
+import { loadConfig } from "../config.js"
+import { findRootRuntimeFiles, resolveStateDir } from "../lib/state.js"
+
+export async function doctor(): Promise<void> {
+  const config = loadConfig()
+  const stateDir = resolveStateDir(config.state?.stateDir)
+  const rootRuntimeFiles = findRootRuntimeFiles()
+
+  console.log("social-cli doctor")
+  console.log(`stateDir: ${stateDir}`)
+
+  if (rootRuntimeFiles.length === 0) {
+    console.log("runtime files: ok (none found in repo root)")
+  } else {
+    console.log(`runtime files: ${rootRuntimeFiles.length} generated file(s) found in repo root`)
+    for (const file of rootRuntimeFiles) {
+      console.log(`  - ${file}`)
+    }
+    console.log("")
+    console.log("These files are generated state. New sync/dispatch output goes under .social-cli/state/ by default.")
+    console.log("Move or remove root-level runtime files after confirming they are no longer needed.")
+  }
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,13 +1,27 @@
 import { loadConfig } from "../config.js"
-import { findRootRuntimeFiles, resolveStateDir } from "../lib/state.js"
+import { findRootRuntimeFiles, migrateRootRuntimeFiles, resolveStateDir } from "../lib/state.js"
 
-export async function doctor(): Promise<void> {
+export async function doctor(opts: { migrate?: boolean } = {}): Promise<void> {
   const config = loadConfig()
-  const stateDir = resolveStateDir(config.state?.stateDir)
-  const rootRuntimeFiles = findRootRuntimeFiles()
+  const configuredStateDir = config.state?.stateDir
+  const stateDir = resolveStateDir(configuredStateDir)
 
   console.log("social-cli doctor")
   console.log(`stateDir: ${stateDir}`)
+
+  if (opts.migrate) {
+    const migrated = migrateRootRuntimeFiles(process.cwd(), configuredStateDir)
+    if (migrated.length === 0) {
+      console.log("migration: no root-level runtime files moved")
+    } else {
+      console.log(`migration: moved ${migrated.length} runtime file(s) into stateDir`)
+      for (const file of migrated) {
+        console.log(`  - ${file.from} → ${file.to}`)
+      }
+    }
+  }
+
+  const rootRuntimeFiles = findRootRuntimeFiles()
 
   if (rootRuntimeFiles.length === 0) {
     console.log("runtime files: ok (none found in repo root)")
@@ -18,6 +32,7 @@ export async function doctor(): Promise<void> {
     }
     console.log("")
     console.log("These files are generated state. New sync/dispatch output goes under .social-cli/state/ by default.")
-    console.log("Move or remove root-level runtime files after confirming they are no longer needed.")
+    console.log("Run `social-cli doctor --migrate` to move root-level runtime files into the state directory.")
+    console.log("Files are not overwritten if a destination already exists; inspect remaining files manually.")
   }
 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -28,6 +28,7 @@ import {
   migrateSharedToPlatformSpecific,
   discoverPlatformFiles,
   readPlatformFile,
+  rootRuntimeWarning,
 } from "../lib/state.js"
 
 interface InboxFile {
@@ -274,6 +275,8 @@ export async function sync(opts: {
   const allowedPlatforms = config.sync?.allowedPlatforms
   const platformIsolation = config.state?.platformIsolation ?? true
   const stateDir = config.state?.stateDir
+  const runtimeWarning = rootRuntimeWarning(stateDir)
+  if (runtimeWarning) console.warn(runtimeWarning)
 
   // Determine target platforms
   let targetPlatforms: string[]

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ export interface DispatchConfig {
 export interface StateConfig {
   /** Enable platform-specific state files (default: true) */
   platformIsolation?: boolean
-  /** Directory for state files (default: cwd) */
+  /** Directory for generated runtime state files (default: .social-cli/state under cwd) */
   stateDir?: string
 }
 

--- a/src/lib/state.test.ts
+++ b/src/lib/state.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 import {
   DEFAULT_STATE_DIR,
+  defaultStateDir,
   findRootRuntimeFiles,
   migrateRootRuntimeFiles,
   getPlatformFilePath,
@@ -26,10 +27,11 @@ describe("state paths", () => {
   })
 
   it("defaults generated state to an ignored subdirectory", () => {
-    expect(resolveStateDir()).toBe(join(tempDir, DEFAULT_STATE_DIR))
-    expect(getPlatformFilePath("inbox", "bsky")).toBe(join(tempDir, DEFAULT_STATE_DIR, "inbox-bsky.yaml"))
-    expect(getSharedFilePath("processed")).toBe(join(tempDir, DEFAULT_STATE_DIR, "processed.yaml"))
-    expect(existsSync(join(tempDir, DEFAULT_STATE_DIR))).toBe(true)
+    expect(defaultStateDir()).toBe(join(DEFAULT_STATE_DIR, process.env.AGENT_ID ?? "default"))
+    expect(resolveStateDir()).toBe(join(tempDir, DEFAULT_STATE_DIR, process.env.AGENT_ID ?? "default"))
+    expect(getPlatformFilePath("inbox", "bsky")).toBe(join(tempDir, DEFAULT_STATE_DIR, process.env.AGENT_ID ?? "default", "inbox-bsky.yaml"))
+    expect(getSharedFilePath("processed")).toBe(join(tempDir, DEFAULT_STATE_DIR, process.env.AGENT_ID ?? "default", "processed.yaml"))
+    expect(existsSync(join(tempDir, DEFAULT_STATE_DIR, process.env.AGENT_ID ?? "default"))).toBe(true)
   })
 
   it("honors explicit stateDir", () => {
@@ -58,9 +60,9 @@ describe("state paths", () => {
 
     expect(migrated).toHaveLength(1)
     expect(migrated[0].from).toBe(join(tempDir, "inbox-bsky.yaml"))
-    expect(migrated[0].to).toBe(join(tempDir, DEFAULT_STATE_DIR, "inbox-bsky.yaml"))
+    expect(migrated[0].to).toBe(join(tempDir, DEFAULT_STATE_DIR, process.env.AGENT_ID ?? "default", "inbox-bsky.yaml"))
     expect(existsSync(join(tempDir, "inbox-bsky.yaml"))).toBe(false)
-    expect(existsSync(join(tempDir, DEFAULT_STATE_DIR, "inbox-bsky.yaml"))).toBe(true)
+    expect(existsSync(join(tempDir, DEFAULT_STATE_DIR, process.env.AGENT_ID ?? "default", "inbox-bsky.yaml"))).toBe(true)
     expect(existsSync(join(tempDir, "notes.md"))).toBe(true)
   })
 

--- a/src/lib/state.test.ts
+++ b/src/lib/state.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os"
 import {
   DEFAULT_STATE_DIR,
   defaultStateDir,
+  defaultStateId,
   findRootRuntimeFiles,
   migrateRootRuntimeFiles,
   getPlatformFilePath,
@@ -15,23 +16,32 @@ import {
 describe("state paths", () => {
   const originalCwd = process.cwd()
   let tempDir: string
+  const originalEnv = { ...process.env }
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), "social-cli-state-test-"))
     process.chdir(tempDir)
   })
 
+  function expectedStateId(): string {
+    return process.env.SOCIAL_CLI_STATE_ID
+      ?? process.env.SOCIAL_CLI_AGENT_ID
+      ?? process.env.AGENT_ID
+      ?? "default"
+  }
+
   afterEach(() => {
     process.chdir(originalCwd)
+    process.env = { ...originalEnv }
     rmSync(tempDir, { recursive: true, force: true })
   })
 
   it("defaults generated state to an ignored subdirectory", () => {
-    expect(defaultStateDir()).toBe(join(DEFAULT_STATE_DIR, process.env.AGENT_ID ?? "default"))
-    expect(resolveStateDir()).toBe(join(tempDir, DEFAULT_STATE_DIR, process.env.AGENT_ID ?? "default"))
-    expect(getPlatformFilePath("inbox", "bsky")).toBe(join(tempDir, DEFAULT_STATE_DIR, process.env.AGENT_ID ?? "default", "inbox-bsky.yaml"))
-    expect(getSharedFilePath("processed")).toBe(join(tempDir, DEFAULT_STATE_DIR, process.env.AGENT_ID ?? "default", "processed.yaml"))
-    expect(existsSync(join(tempDir, DEFAULT_STATE_DIR, process.env.AGENT_ID ?? "default"))).toBe(true)
+    expect(defaultStateDir()).toBe(join(DEFAULT_STATE_DIR, expectedStateId()))
+    expect(resolveStateDir()).toBe(join(tempDir, DEFAULT_STATE_DIR, expectedStateId()))
+    expect(getPlatformFilePath("inbox", "bsky")).toBe(join(tempDir, DEFAULT_STATE_DIR, expectedStateId(), "inbox-bsky.yaml"))
+    expect(getSharedFilePath("processed")).toBe(join(tempDir, DEFAULT_STATE_DIR, expectedStateId(), "processed.yaml"))
+    expect(existsSync(join(tempDir, DEFAULT_STATE_DIR, expectedStateId()))).toBe(true)
   })
 
   it("honors explicit stateDir", () => {
@@ -60,9 +70,9 @@ describe("state paths", () => {
 
     expect(migrated).toHaveLength(1)
     expect(migrated[0].from).toBe(join(tempDir, "inbox-bsky.yaml"))
-    expect(migrated[0].to).toBe(join(tempDir, DEFAULT_STATE_DIR, process.env.AGENT_ID ?? "default", "inbox-bsky.yaml"))
+    expect(migrated[0].to).toBe(join(tempDir, DEFAULT_STATE_DIR, expectedStateId(), "inbox-bsky.yaml"))
     expect(existsSync(join(tempDir, "inbox-bsky.yaml"))).toBe(false)
-    expect(existsSync(join(tempDir, DEFAULT_STATE_DIR, process.env.AGENT_ID ?? "default", "inbox-bsky.yaml"))).toBe(true)
+    expect(existsSync(join(tempDir, DEFAULT_STATE_DIR, expectedStateId(), "inbox-bsky.yaml"))).toBe(true)
     expect(existsSync(join(tempDir, "notes.md"))).toBe(true)
   })
 
@@ -74,6 +84,24 @@ describe("state paths", () => {
     expect(migrateRootRuntimeFiles()).toEqual([])
     expect(existsSync(join(tempDir, "inbox-bsky.yaml"))).toBe(true)
     expect(existsSync(stateFile)).toBe(true)
+  })
+
+
+  it("supports generic non-Letta state IDs", () => {
+    delete process.env.AGENT_ID
+    process.env.SOCIAL_CLI_STATE_ID = "claude/reviewer 1"
+
+    expect(defaultStateId()).toBe("claude/reviewer 1")
+    expect(defaultStateDir()).toBe(join(DEFAULT_STATE_DIR, "claude-reviewer-1"))
+    expect(getPlatformFilePath("inbox", "x")).toBe(join(tempDir, DEFAULT_STATE_DIR, "claude-reviewer-1", "inbox-x.yaml"))
+  })
+
+  it("falls back to SOCIAL_CLI_AGENT_ID before AGENT_ID", () => {
+    process.env.AGENT_ID = "letta-agent"
+    process.env.SOCIAL_CLI_AGENT_ID = "other-agent"
+
+    expect(defaultStateId()).toBe("other-agent")
+    expect(defaultStateDir()).toBe(join(DEFAULT_STATE_DIR, "other-agent"))
   })
 
 })

--- a/src/lib/state.test.ts
+++ b/src/lib/state.test.ts
@@ -5,7 +5,6 @@ import { tmpdir } from "node:os"
 import {
   DEFAULT_STATE_DIR,
   defaultStateDir,
-  defaultStateId,
   findRootRuntimeFiles,
   migrateRootRuntimeFiles,
   getPlatformFilePath,
@@ -23,13 +22,6 @@ describe("state paths", () => {
     process.chdir(tempDir)
   })
 
-  function expectedStateId(): string {
-    return process.env.SOCIAL_CLI_STATE_ID
-      ?? process.env.SOCIAL_CLI_AGENT_ID
-      ?? process.env.AGENT_ID
-      ?? "default"
-  }
-
   afterEach(() => {
     process.chdir(originalCwd)
     process.env = { ...originalEnv }
@@ -37,11 +29,11 @@ describe("state paths", () => {
   })
 
   it("defaults generated state to an ignored subdirectory", () => {
-    expect(defaultStateDir()).toBe(join(DEFAULT_STATE_DIR, expectedStateId()))
-    expect(resolveStateDir()).toBe(join(tempDir, DEFAULT_STATE_DIR, expectedStateId()))
-    expect(getPlatformFilePath("inbox", "bsky")).toBe(join(tempDir, DEFAULT_STATE_DIR, expectedStateId(), "inbox-bsky.yaml"))
-    expect(getSharedFilePath("processed")).toBe(join(tempDir, DEFAULT_STATE_DIR, expectedStateId(), "processed.yaml"))
-    expect(existsSync(join(tempDir, DEFAULT_STATE_DIR, expectedStateId()))).toBe(true)
+    expect(defaultStateDir()).toBe(process.env.AGENT_ID ? join(DEFAULT_STATE_DIR, "agents", process.env.AGENT_ID) : DEFAULT_STATE_DIR)
+    expect(resolveStateDir()).toBe(process.env.AGENT_ID ? join(tempDir, DEFAULT_STATE_DIR, "agents", process.env.AGENT_ID) : join(tempDir, DEFAULT_STATE_DIR))
+    expect(getPlatformFilePath("inbox", "bsky")).toBe(process.env.AGENT_ID ? join(tempDir, DEFAULT_STATE_DIR, "agents", process.env.AGENT_ID, "inbox-bsky.yaml") : join(tempDir, DEFAULT_STATE_DIR, "inbox-bsky.yaml"))
+    expect(getSharedFilePath("processed")).toBe(process.env.AGENT_ID ? join(tempDir, DEFAULT_STATE_DIR, "agents", process.env.AGENT_ID, "processed.yaml") : join(tempDir, DEFAULT_STATE_DIR, "processed.yaml"))
+    expect(existsSync(process.env.AGENT_ID ? join(tempDir, DEFAULT_STATE_DIR, "agents", process.env.AGENT_ID) : join(tempDir, DEFAULT_STATE_DIR))).toBe(true)
   })
 
   it("honors explicit stateDir", () => {
@@ -70,9 +62,9 @@ describe("state paths", () => {
 
     expect(migrated).toHaveLength(1)
     expect(migrated[0].from).toBe(join(tempDir, "inbox-bsky.yaml"))
-    expect(migrated[0].to).toBe(join(tempDir, DEFAULT_STATE_DIR, expectedStateId(), "inbox-bsky.yaml"))
+    expect(migrated[0].to).toBe(process.env.AGENT_ID ? join(tempDir, DEFAULT_STATE_DIR, "agents", process.env.AGENT_ID, "inbox-bsky.yaml") : join(tempDir, DEFAULT_STATE_DIR, "inbox-bsky.yaml"))
     expect(existsSync(join(tempDir, "inbox-bsky.yaml"))).toBe(false)
-    expect(existsSync(join(tempDir, DEFAULT_STATE_DIR, expectedStateId(), "inbox-bsky.yaml"))).toBe(true)
+    expect(existsSync(process.env.AGENT_ID ? join(tempDir, DEFAULT_STATE_DIR, "agents", process.env.AGENT_ID, "inbox-bsky.yaml") : join(tempDir, DEFAULT_STATE_DIR, "inbox-bsky.yaml"))).toBe(true)
     expect(existsSync(join(tempDir, "notes.md"))).toBe(true)
   })
 
@@ -87,21 +79,20 @@ describe("state paths", () => {
   })
 
 
-  it("supports generic non-Letta state IDs", () => {
-    delete process.env.AGENT_ID
-    process.env.SOCIAL_CLI_STATE_ID = "claude/reviewer 1"
+  it("supports explicit state dir env override", () => {
+    process.env.SOCIAL_CLI_STATE_DIR = "custom-state"
 
-    expect(defaultStateId()).toBe("claude/reviewer 1")
-    expect(defaultStateDir()).toBe(join(DEFAULT_STATE_DIR, "claude-reviewer-1"))
-    expect(getPlatformFilePath("inbox", "x")).toBe(join(tempDir, DEFAULT_STATE_DIR, "claude-reviewer-1", "inbox-x.yaml"))
+    expect(defaultStateDir()).toBe("custom-state")
+    expect(resolveStateDir()).toBe(join(tempDir, "custom-state"))
+    expect(getPlatformFilePath("inbox", "x")).toBe(join(tempDir, "custom-state", "inbox-x.yaml"))
   })
 
-  it("falls back to SOCIAL_CLI_AGENT_ID before AGENT_ID", () => {
-    process.env.AGENT_ID = "letta-agent"
-    process.env.SOCIAL_CLI_AGENT_ID = "other-agent"
+  it("falls back to shared state when no agent env is available", () => {
+    delete process.env.AGENT_ID
+    delete process.env.SOCIAL_CLI_STATE_DIR
 
-    expect(defaultStateId()).toBe("other-agent")
-    expect(defaultStateDir()).toBe(join(DEFAULT_STATE_DIR, "other-agent"))
+    expect(defaultStateDir()).toBe(DEFAULT_STATE_DIR)
+    expect(resolveStateDir()).toBe(join(tempDir, DEFAULT_STATE_DIR))
   })
 
 })

--- a/src/lib/state.test.ts
+++ b/src/lib/state.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os"
 import {
   DEFAULT_STATE_DIR,
   findRootRuntimeFiles,
+  migrateRootRuntimeFiles,
   getPlatformFilePath,
   getSharedFilePath,
   resolveStateDir,
@@ -48,4 +49,29 @@ describe("state paths", () => {
       "sent_ledger.yaml",
     ])
   })
+
+  it("migrates root runtime files into the state directory without overwriting", () => {
+    writeFileSync(join(tempDir, "inbox-bsky.yaml"), "notifications: []\n")
+    writeFileSync(join(tempDir, "notes.md"), "not runtime\n")
+
+    const migrated = migrateRootRuntimeFiles()
+
+    expect(migrated).toHaveLength(1)
+    expect(migrated[0].from).toBe(join(tempDir, "inbox-bsky.yaml"))
+    expect(migrated[0].to).toBe(join(tempDir, DEFAULT_STATE_DIR, "inbox-bsky.yaml"))
+    expect(existsSync(join(tempDir, "inbox-bsky.yaml"))).toBe(false)
+    expect(existsSync(join(tempDir, DEFAULT_STATE_DIR, "inbox-bsky.yaml"))).toBe(true)
+    expect(existsSync(join(tempDir, "notes.md"))).toBe(true)
+  })
+
+  it("does not overwrite existing files during migration", () => {
+    const stateFile = getPlatformFilePath("inbox", "bsky")
+    writeFileSync(join(tempDir, "inbox-bsky.yaml"), "root: true\n")
+    writeFileSync(stateFile, "state: true\n")
+
+    expect(migrateRootRuntimeFiles()).toEqual([])
+    expect(existsSync(join(tempDir, "inbox-bsky.yaml"))).toBe(true)
+    expect(existsSync(stateFile)).toBe(true)
+  })
+
 })

--- a/src/lib/state.test.ts
+++ b/src/lib/state.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import {
+  DEFAULT_STATE_DIR,
+  findRootRuntimeFiles,
+  getPlatformFilePath,
+  getSharedFilePath,
+  resolveStateDir,
+} from "./state.js"
+
+describe("state paths", () => {
+  const originalCwd = process.cwd()
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "social-cli-state-test-"))
+    process.chdir(tempDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it("defaults generated state to an ignored subdirectory", () => {
+    expect(resolveStateDir()).toBe(join(tempDir, DEFAULT_STATE_DIR))
+    expect(getPlatformFilePath("inbox", "bsky")).toBe(join(tempDir, DEFAULT_STATE_DIR, "inbox-bsky.yaml"))
+    expect(getSharedFilePath("processed")).toBe(join(tempDir, DEFAULT_STATE_DIR, "processed.yaml"))
+    expect(existsSync(join(tempDir, DEFAULT_STATE_DIR))).toBe(true)
+  })
+
+  it("honors explicit stateDir", () => {
+    expect(getPlatformFilePath("sent_ledger", "x", "runtime")).toBe(join(tempDir, "runtime", "sent_ledger-x.yaml"))
+    expect(existsSync(join(tempDir, "runtime"))).toBe(true)
+  })
+
+  it("finds generated runtime files in the repo root", () => {
+    writeFileSync(join(tempDir, "inbox-bsky.yaml"), "notifications: []\n")
+    writeFileSync(join(tempDir, "dispatch_result-x.yaml"), "results: []\n")
+    writeFileSync(join(tempDir, "sent_ledger.yaml"), "entries: []\n")
+    writeFileSync(join(tempDir, "notes.md"), "not runtime\n")
+
+    expect(findRootRuntimeFiles()).toEqual([
+      "dispatch_result-x.yaml",
+      "inbox-bsky.yaml",
+      "sent_ledger.yaml",
+    ])
+  })
+})

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -11,7 +11,7 @@
  */
 
 import { existsSync, readFileSync, mkdirSync, copyFileSync, readdirSync, renameSync } from "node:fs"
-import { resolve, join } from "node:path"
+import { resolve, join, basename } from "node:path"
 import { parse, stringify } from "yaml"
 import { writeFileAtomic } from "../util/fs.js"
 
@@ -36,8 +36,18 @@ export const DEFAULT_STATE_DIR = ".social-cli/state"
  * repository root so agents do not accidentally stage inboxes, ledgers, or
  * dispatch results.
  */
+function sanitizeStateSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "-").slice(0, 120) || "default"
+}
+
+export function defaultStateDir(): string {
+  const agentId = process.env.AGENT_ID
+  if (agentId) return join(DEFAULT_STATE_DIR, sanitizeStateSegment(agentId))
+  return join(DEFAULT_STATE_DIR, "default")
+}
+
 export function resolveStateDir(stateDir?: string): string {
-  return resolve(process.cwd(), stateDir ?? DEFAULT_STATE_DIR)
+  return resolve(process.cwd(), stateDir ?? defaultStateDir())
 }
 
 function ensureStateDir(stateDir?: string): string {
@@ -347,6 +357,17 @@ export function findRootRuntimeFiles(cwd = process.cwd()): string[] {
     .sort()
 }
 
+
+export function rootRuntimeWarning(stateDir?: string): string | null {
+  const files = findRootRuntimeFiles()
+  if (files.length === 0) return null
+
+  const preview = files.slice(0, 5).join(", ")
+  const suffix = files.length > 5 ? `, and ${files.length - 5} more` : ""
+  return `[warn] Found ${files.length} legacy runtime state file(s) in repo root (${preview}${suffix}). `
+    + `Current stateDir is ${resolveStateDir(stateDir)}. `
+    + "Run `social-cli doctor --migrate` to move generated state into the configured state directory."
+}
 
 export interface RuntimeFileMigration {
   from: string

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -10,7 +10,7 @@
  * replay protection and pruning operate unambiguously within platform partitions.
  */
 
-import { existsSync, readFileSync, mkdirSync, copyFileSync, readdirSync } from "node:fs"
+import { existsSync, readFileSync, mkdirSync, copyFileSync, readdirSync, renameSync } from "node:fs"
 import { resolve, join } from "node:path"
 import { parse, stringify } from "yaml"
 import { writeFileAtomic } from "../util/fs.js"
@@ -345,4 +345,31 @@ export function findRootRuntimeFiles(cwd = process.cwd()): string[] {
   return readdirSync(cwd)
     .filter((file) => ROOT_RUNTIME_PATTERNS.some((pattern) => pattern.test(file)))
     .sort()
+}
+
+
+export interface RuntimeFileMigration {
+  from: string
+  to: string
+}
+
+/**
+ * Move legacy root-level runtime files into the configured state directory.
+ *
+ * Existing destination files are never overwritten; those source files remain
+ * in place so the user can inspect/merge them manually.
+ */
+export function migrateRootRuntimeFiles(cwd = process.cwd(), stateDir?: string): RuntimeFileMigration[] {
+  const targetDir = ensureStateDir(stateDir)
+  const migrated: RuntimeFileMigration[] = []
+
+  for (const file of findRootRuntimeFiles(cwd)) {
+    const from = resolve(cwd, file)
+    const to = resolve(targetDir, file)
+    if (existsSync(to)) continue
+    renameSync(from, to)
+    migrated.push({ from, to })
+  }
+
+  return migrated
 }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -40,15 +40,10 @@ function sanitizeStateSegment(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]/g, "-").slice(0, 120) || "default"
 }
 
-export function defaultStateId(): string {
-  return process.env.SOCIAL_CLI_STATE_ID
-    ?? process.env.SOCIAL_CLI_AGENT_ID
-    ?? process.env.AGENT_ID
-    ?? "default"
-}
-
 export function defaultStateDir(): string {
-  return join(DEFAULT_STATE_DIR, sanitizeStateSegment(defaultStateId()))
+  if (process.env.SOCIAL_CLI_STATE_DIR) return process.env.SOCIAL_CLI_STATE_DIR
+  if (process.env.AGENT_ID) return join(DEFAULT_STATE_DIR, "agents", sanitizeStateSegment(process.env.AGENT_ID))
+  return DEFAULT_STATE_DIR
 }
 
 export function resolveStateDir(stateDir?: string): string {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -40,10 +40,15 @@ function sanitizeStateSegment(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]/g, "-").slice(0, 120) || "default"
 }
 
+export function defaultStateId(): string {
+  return process.env.SOCIAL_CLI_STATE_ID
+    ?? process.env.SOCIAL_CLI_AGENT_ID
+    ?? process.env.AGENT_ID
+    ?? "default"
+}
+
 export function defaultStateDir(): string {
-  const agentId = process.env.AGENT_ID
-  if (agentId) return join(DEFAULT_STATE_DIR, sanitizeStateSegment(agentId))
-  return join(DEFAULT_STATE_DIR, "default")
+  return join(DEFAULT_STATE_DIR, sanitizeStateSegment(defaultStateId()))
 }
 
 export function resolveStateDir(stateDir?: string): string {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -11,19 +11,39 @@
  */
 
 import { existsSync, readFileSync, mkdirSync, copyFileSync, readdirSync } from "node:fs"
-import { resolve, join, basename, dirname } from "node:path"
+import { resolve, join } from "node:path"
 import { parse, stringify } from "yaml"
 import { writeFileAtomic } from "../util/fs.js"
 
 /** State file types that support platform isolation */
-export type StateFileType = "inbox" | "outbox" | "sent_ledger" | "processed"
+export type StateFileType = "inbox" | "outbox" | "sent_ledger" | "processed" | "dispatch_result"
 
 /** Configuration for platform isolation */
 export interface PlatformIsolationConfig {
   /** Enable platform-specific state files (default: true) */
   enabled: boolean
-  /** Directory for state files (default: cwd) */
+  /** Directory for state files (default: .social-cli/state under cwd) */
   stateDir?: string
+}
+
+/** Default directory for generated runtime state. */
+export const DEFAULT_STATE_DIR = ".social-cli/state"
+
+/**
+ * Resolve the state directory for generated runtime files.
+ *
+ * Defaulting to an ignored subdirectory keeps sync/dispatch output out of the
+ * repository root so agents do not accidentally stage inboxes, ledgers, or
+ * dispatch results.
+ */
+export function resolveStateDir(stateDir?: string): string {
+  return resolve(process.cwd(), stateDir ?? DEFAULT_STATE_DIR)
+}
+
+function ensureStateDir(stateDir?: string): string {
+  const baseDir = resolveStateDir(stateDir)
+  mkdirSync(baseDir, { recursive: true })
+  return baseDir
 }
 
 /**
@@ -39,7 +59,7 @@ export function getPlatformFilePath(
   platform: string,
   stateDir?: string
 ): string {
-  const baseDir = stateDir ?? process.cwd()
+  const baseDir = ensureStateDir(stateDir)
   const filename = `${fileType}-${platform}.yaml`
   return resolve(baseDir, filename)
 }
@@ -52,7 +72,7 @@ export function getSharedFilePath(
   fileType: StateFileType,
   stateDir?: string
 ): string {
-  const baseDir = stateDir ?? process.cwd()
+  const baseDir = ensureStateDir(stateDir)
   return resolve(baseDir, `${fileType}.yaml`)
 }
 
@@ -163,7 +183,7 @@ export function discoverPlatformFiles(
   fileType: StateFileType,
   stateDir?: string
 ): string[] {
-  const baseDir = stateDir ?? process.cwd()
+  const baseDir = resolveStateDir(stateDir)
   const platforms: string[] = []
   
   if (!existsSync(baseDir)) return platforms
@@ -291,7 +311,7 @@ export function archivePlatformOutbox(
   const outboxPath = getPlatformFilePath("outbox", platform, stateDir)
   if (!existsSync(outboxPath)) return null
   
-  const baseDir = stateDir ?? process.cwd()
+  const baseDir = ensureStateDir(stateDir)
   const archiveDir = resolve(baseDir, "outbox_archive")
   mkdirSync(archiveDir, { recursive: true })
   
@@ -303,4 +323,26 @@ export function archivePlatformOutbox(
   copyFileSync(outboxPath, archivedPath)
   
   return archivedPath
+}
+
+const ROOT_RUNTIME_PATTERNS = [
+  /^inbox(?:-[^.]+)?\.ya?ml$/,
+  /^outbox(?:-[^.]+)?\.ya?ml$/,
+  /^processed(?:-[^.]+)?\.ya?ml$/,
+  /^sent_ledger(?:-[^.]+)?\.ya?ml$/,
+  /^dispatch_result(?:-[^.]+)?\.ya?ml$/,
+  /^feed\.ya?ml$/,
+  /^[a-z]+_feed\.ya?ml$/,
+  /^[a-z]+_inbox\.ya?ml$/,
+]
+
+/**
+ * Find generated runtime files that still live in the repo root.
+ * Useful for doctor-style warnings after the default state dir moved.
+ */
+export function findRootRuntimeFiles(cwd = process.cwd()): string[] {
+  if (!existsSync(cwd)) return []
+  return readdirSync(cwd)
+    .filter((file) => ROOT_RUNTIME_PATTERNS.some((pattern) => pattern.test(file)))
+    .sort()
 }


### PR DESCRIPTION
## Summary
- Moves generated runtime state paths to `.social-cli/state/` by default so inboxes, ledgers, processed sets, dispatch results, and archived outboxes do not pollute the repository root.
- Adds ignore rules for generated state files and a `social-cli doctor` command that warns about legacy root-level runtime files.
- Adds regression coverage for default state paths and root runtime-file detection.

## Test plan
- `bun ./node_modules/vitest/vitest.mjs run src/lib/state.test.ts`
- `bun src/cli.ts doctor`
- `bun src/cli.ts check -p bsky`

Note: `pnpm`/`node` are unavailable in this Railway env, so validation used Bun with the existing repository dependencies.

Fixes #60

👾 Generated with [Letta Code](https://letta.com)