### PR TITLE
fix: support singular post platform in dispatch

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -114,6 +114,11 @@ dispatch:
       text: "Interesting development in agent architectures today."
       platforms: [bsky, x]
 
+  # Post to one platform
+  - post:
+      platform: x
+      text: "Interesting development in agent architectures today."
+
   # Post different text per platform
   - post:
       platforms:

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ dispatch:
       text: "Hello from social-cli"
       platforms: [bsky, x]
 
+  - post:
+      platform: x
+      text: "Hello from X only"
+
   - thread:
       platform: bsky
       posts:

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -298,6 +298,7 @@ async function dispatchPlatform(
       else if (action.highlight) actionPlatform = action.highlight.platform
       else if (action.follow) actionPlatform = action.follow.platform
       else if (action.like) actionPlatform = action.like.platform
+      else if (action.post?.platform) actionPlatform = action.post.platform
       else if (action.post?.platforms) {
         const platforms = action.post.platforms
         actionPlatform = Array.isArray(platforms) ? platforms[0] : Object.keys(platforms)[0]
@@ -372,7 +373,9 @@ async function dispatchPlatform(
           ? action.post.platforms
           : action.post.platforms && typeof action.post.platforms === "object"
             ? Object.keys(action.post.platforms)
-            : ["bsky"]
+            : action.post.platform
+              ? [action.post.platform]
+              : ["bsky"]
         for (const plat of platforms) {
           const key = postKey(plat, action.post.text, action.post.idempotencyKey, action.post.quoteId, action.post.replyTo)
           if (sentKeys.has(key)) {
@@ -568,6 +571,9 @@ async function dispatchPlatform(
         for (const plat of p.platforms) {
           targets.push({ platform: plat, text: p.text })
         }
+      } else if (p.text && p.platform) {
+        // Same text, one explicit platform
+        targets.push({ platform: p.platform, text: p.text })
       } else if (p.text) {
         // Single platform not specified — default to bsky
         targets.push({ platform: "bsky", text: p.text })

--- a/src/commands/validate.test.ts
+++ b/src/commands/validate.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { validateOutbox } from "./validate.js"
+
+describe("validateOutbox post actions", () => {
+  it("accepts a singular platform when post text is present", () => {
+    const result = validateOutbox({
+      dispatch: [
+        {
+          post: {
+            platform: "x",
+            text: "hello from x",
+          },
+        },
+      ],
+    })
+
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it("rejects a singular platform without post text", () => {
+    const result = validateOutbox({
+      dispatch: [
+        {
+          post: {
+            platform: "x",
+          },
+        },
+      ],
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain("Action 0: post needs 'text' or 'platforms' with per-platform text")
+  })
+
+  it("rejects mixed singular and plural platform selectors", () => {
+    const result = validateOutbox({
+      dispatch: [
+        {
+          post: {
+            platform: "x",
+            platforms: ["bsky"],
+            text: "ambiguous target",
+          },
+        },
+      ],
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain("Action 0: post cannot have both 'platform' and 'platforms'")
+  })
+})

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -136,7 +136,7 @@ export function validateOutbox(outbox: OutboxFile): ValidationResult {
 
     if (type === "post") {
       const p = action.post!
-      if (!p.text && !p.platform && !p.platforms) {
+      if (!p.text && !p.platforms) {
         errors.push(`${prefix}: post needs 'text' or 'platforms' with per-platform text`)
       }
       if (p.platform && p.platforms) {

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -16,6 +16,7 @@ export interface OutboxAction {
   }
   post?: {
     text?: string
+    platform?: string
     platforms?: string[] | Record<string, string>
     /** Embed this post as a quote (AT URI or tweet ID). */
     quoteId?: string
@@ -135,13 +136,22 @@ export function validateOutbox(outbox: OutboxFile): ValidationResult {
 
     if (type === "post") {
       const p = action.post!
-      if (!p.text && !p.platforms) {
+      if (!p.text && !p.platform && !p.platforms) {
         errors.push(`${prefix}: post needs 'text' or 'platforms' with per-platform text`)
+      }
+      if (p.platform && p.platforms) {
+        errors.push(`${prefix}: post cannot have both 'platform' and 'platforms'`)
       }
       if (p.quoteId && p.replyTo) {
         errors.push(`${prefix}: post cannot have both 'quoteId' and 'replyTo'`)
       }
       // Validate char limits for each platform
+      if (p.text && p.platform) {
+        const limit = PLATFORM_LIMITS[p.platform]
+        if (limit && p.text.length > limit.chars) {
+          errors.push(`${prefix}: post text exceeds ${p.platform} limit (${p.text.length}/${limit.chars})`)
+        }
+      }
       if (p.text && p.platforms && Array.isArray(p.platforms)) {
         for (const plat of p.platforms) {
           const limit = PLATFORM_LIMITS[plat]


### PR DESCRIPTION
## Summary
- Treat `post.platform` as an explicit single-platform dispatch target instead of silently defaulting to Bluesky.
- Validate mixed `platform`/`platforms` post actions and apply character-limit checks for singular post targets.
- Document singular `platform` examples in the README and agent guide.

## Test plan
- [x] `tsc --noEmit false --outDir dist`
- [x] `vitest run src/util/yaml.test.ts`
- [x] Manual dry-run: `post.platform: x` validates and no longer falls through to the Bluesky default
- [x] Manual dry-run: mixed `platform` + `platforms` fails validation

👾 Generated with [Letta Code](https://letta.com)