### PR TITLE
fix: warn on explicit dispatch state mismatch

### DIFF
--- a/src/commands/dispatch.test.ts
+++ b/src/commands/dispatch.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
-import { stringify } from "yaml"
+import { parse, stringify } from "yaml"
 import type { SocialPlatform } from "../platforms/types.js"
 
 const { runHooksMock, getPlatformAsyncMock } = vi.hoisted(() => ({
@@ -44,6 +44,59 @@ function createPlatform(overrides: Partial<SocialPlatform> = {}): SocialPlatform
     ...overrides,
   }
 }
+
+
+describe("dispatch explicit-file state warnings", () => {
+  const originalCwd = process.cwd()
+  let testDir: string
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "social-cli-dispatch-warning-test-"))
+    process.chdir(testDir)
+    writeFileSync(join(testDir, "config.yaml"), stringify({ accounts: {} }))
+
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    runHooksMock.mockReset()
+    runHooksMock.mockResolvedValue({ results: [], blocked: false, abort: false })
+    getPlatformAsyncMock.mockReset()
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    process.chdir(originalCwd)
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it("warns when an explicit root outbox will use stateDir companions instead of root inbox files", async () => {
+    writeFileSync(
+      join(testDir, "inbox-bsky.yaml"),
+      stringify({
+        notifications: [
+          { id: "at://ignored-post", postId: "at://ignored-post", platform: "bsky", type: "reply" },
+        ],
+        _sync: { totalCount: 1 },
+      }),
+    )
+    writeFileSync(
+      join(testDir, "outbox-bsky.yaml"),
+      stringify({
+        dispatch: [{ ignore: { id: "at://ignored-post", reason: "already handled" } }],
+      }),
+    )
+
+    await dispatch({ file: "outbox-bsky.yaml" })
+
+    const warning = warnSpy.mock.calls.map((call: unknown[]) => call.join(" ")).join("\n")
+    expect(warning).toContain("explicit outbox")
+    expect(warning).toContain("outside active stateDir")
+    expect(warning).toContain("dispatch will not prune those files")
+
+    const rootInbox = parse(readFileSync(join(testDir, "inbox-bsky.yaml"), "utf8"))
+    expect(rootInbox.notifications.map((n: any) => n.id)).toEqual(["at://ignored-post"])
+  })
+})
+
 
 describe("dispatch hook alignment", () => {
   const originalCwd = process.cwd()

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -13,7 +13,7 @@
  */
 
 import { readFileSync, existsSync, mkdirSync, rmSync } from "node:fs"
-import { resolve, join, basename } from "node:path"
+import { resolve, join, basename, dirname } from "node:path"
 import { createHash } from "node:crypto"
 import { parse, stringify } from "yaml"
 import { getPlatformAsync } from "../platforms/index.js"
@@ -250,6 +250,25 @@ async function dispatchPlatform(
     : platformIsolation
       ? getPlatformFilePath("outbox", platform, stateDir)
       : getSharedFilePath("outbox", stateDir)
+
+  if (opts.explicitFile && platformIsolation) {
+    const activeStateDir = resolveStateDir(stateDir)
+    const explicitDir = resolve(dirname(outboxPath))
+    if (explicitDir !== activeStateDir) {
+      const companionInbox = resolve(explicitDir, `inbox-${platform}.yaml`)
+      const companionSharedInbox = resolve(explicitDir, "inbox.yaml")
+      const hasCompanionInbox = existsSync(companionInbox) || existsSync(companionSharedInbox)
+      const inboxHint = hasCompanionInbox
+        ? ` Found inbox file(s) next to the outbox; dispatch will not prune those files.`
+        : ""
+      console.warn(
+        `[${platform}] Warning: explicit outbox ${outboxPath} is outside active stateDir ${activeStateDir}. `
+          + `Dispatch will still use inbox/processed/result files in the active stateDir, not next to the outbox.`
+          + inboxHint
+          + " Run `social-cli doctor --migrate`, move the outbox into stateDir, or set SOCIAL_CLI_STATE_DIR intentionally.",
+      )
+    }
+  }
 
   if (!existsSync(outboxPath)) {
     console.log(`[${platform}] No outbox file found at ${outboxPath}, skipping.`)


### PR DESCRIPTION
## Summary
- warn when `dispatch <explicit outbox>` is outside the active stateDir while platform isolation is enabled
- call out adjacent inbox files that will not be pruned by dispatch
- add regression coverage for the legacy root outbox/root inbox mismatch

## Validation
- `bunx vitest run src/commands/dispatch.test.ts`
- `bunx tsc --noEmit false --outDir dist`

👾 Generated with [Letta Code](https://letta.com)