### PR TITLE
feat(state): configurable outbox-archive directory (+ honor state/dispatch config)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,30 @@ social-cli dispatch                    # execute decisions, mark processed
 
 The agent loop handles bookkeeping — marking notifications as processed, deduplicating, archiving outboxes. Agents read `inbox.yaml`, write decisions to `outbox.yaml`, and `dispatch` executes them.
 
+### State directory & archive
+
+State files (`inbox`, `outbox`, `sent_ledger`, `processed`) live in the state
+directory (`state.stateDir` in `config.yaml`, default: the current directory).
+Each `dispatch` archives the outbox it just sent to a per-run
+`<timestamp>_outbox-<platform>.yaml` under an archive directory — these
+accumulate over time.
+
+The archive directory is configurable, which is useful when the state directory
+is version-controlled and you don't want the high-churn per-run archives tracked:
+
+```yaml
+state:
+  stateDir: ./state          # where inbox/outbox/ledgers live (default: cwd)
+  archiveDir: outbox_archive  # relative → under stateDir; absolute → as-is (default: "outbox_archive")
+```
+
+Or, without a config file (e.g. when a harness invokes `social-cli` headless),
+set `SOCIAL_CLI_ARCHIVE_DIR` — it takes precedence over `state.archiveDir`:
+
+```bash
+SOCIAL_CLI_ARCHIVE_DIR=/var/tmp/social-archive social-cli dispatch
+```
+
 ### Quick commands
 
 For actions that don't come from notifications:

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -31,6 +31,7 @@ import {
   readPlatformFile,
   writePlatformFile,
   readSharedFile,
+  resolveArchiveDir,
 } from "../lib/state.js"
 
 /**
@@ -676,8 +677,11 @@ async function dispatchPlatform(
     }
   }
 
-  // Archive outbox
-  const archiveDir = resolve(process.cwd(), "outbox_archive")
+  // Archive outbox. Configurable via SOCIAL_CLI_ARCHIVE_DIR / state.archiveDir
+  // (default <stateDir>/outbox_archive) so the high-churn per-run archive can
+  // be routed out of version-controlled state. Also fixes the prior
+  // process.cwd() hardcode to respect stateDir like the other state files.
+  const archiveDir = resolveArchiveDir(stateDir, config.state?.archiveDir)
   mkdirSync(archiveDir, { recursive: true })
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
   const archivedOutbox = join(archiveDir, `${timestamp}_outbox-${platform}.yaml`)

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,16 @@ export interface StateConfig {
   platformIsolation?: boolean
   /** Directory for state files (default: cwd) */
   stateDir?: string
+  /**
+   * Directory for dispatched-outbox archives (the per-run
+   * `<timestamp>_outbox-<platform>.yaml` files). Relative paths resolve
+   * against the state dir (cwd); absolute paths are used as-is.
+   * Default: "outbox_archive". The `SOCIAL_CLI_ARCHIVE_DIR` env var takes
+   * precedence — handy for headless callers (e.g. a poller framework) that
+   * want to route the high-churn archive out of version-controlled state
+   * without editing a config file.
+   */
+  archiveDir?: string
 }
 
 export interface Config {
@@ -70,6 +80,8 @@ export function loadConfig(): Config {
       return {
         accounts,
         sync: parsed.sync,
+        dispatch: parsed.dispatch,
+        state: parsed.state,
       }
     }
   }

--- a/src/lib/state.test.ts
+++ b/src/lib/state.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach } from "vitest"
+import { resolve } from "node:path"
+import { resolveArchiveDir } from "./state.js"
+
+const ENV = "SOCIAL_CLI_ARCHIVE_DIR"
+
+describe("resolveArchiveDir", () => {
+  afterEach(() => {
+    delete process.env[ENV]
+  })
+
+  it("defaults to <stateDir>/outbox_archive (backward compatible)", () => {
+    expect(resolveArchiveDir("/state")).toBe(resolve("/state", "outbox_archive"))
+  })
+
+  it("falls back to cwd when no stateDir given", () => {
+    expect(resolveArchiveDir()).toBe(resolve(process.cwd(), "outbox_archive"))
+  })
+
+  it("honors a relative config archiveDir (resolved under stateDir)", () => {
+    expect(resolveArchiveDir("/state", "archive")).toBe(resolve("/state", "archive"))
+  })
+
+  it("honors an absolute config archiveDir as-is", () => {
+    expect(resolveArchiveDir("/state", "/abs/archive")).toBe("/abs/archive")
+  })
+
+  it("lets SOCIAL_CLI_ARCHIVE_DIR take precedence over config", () => {
+    process.env[ENV] = "/env/archive"
+    expect(resolveArchiveDir("/state", "config-archive")).toBe("/env/archive")
+  })
+
+  it("resolves a relative env override under stateDir", () => {
+    process.env[ENV] = "env-archive"
+    expect(resolveArchiveDir("/state")).toBe(resolve("/state", "env-archive"))
+  })
+})

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -11,7 +11,7 @@
  */
 
 import { existsSync, readFileSync, mkdirSync, copyFileSync, readdirSync } from "node:fs"
-import { resolve, join, basename, dirname } from "node:path"
+import { resolve, join, basename, dirname, isAbsolute } from "node:path"
 import { parse, stringify } from "yaml"
 import { writeFileAtomic } from "../util/fs.js"
 
@@ -282,21 +282,41 @@ export function pruneInboxByPostId(
 }
 
 /**
- * Archive a platform-specific outbox file after dispatch.
+ * Resolve the directory for dispatched-outbox archives. Precedence:
+ *   1. `SOCIAL_CLI_ARCHIVE_DIR` env var
+ *   2. `archiveDir` argument (from `config.state.archiveDir`)
+ *   3. default: "outbox_archive"
+ * Relative values resolve against `stateDir` (or cwd); absolute values are
+ * used as-is. This lets a caller route the high-churn per-run archive out of
+ * version-controlled state without forking the tool.
+ */
+export function resolveArchiveDir(stateDir?: string, archiveDir?: string): string {
+  const baseDir = stateDir ?? process.cwd()
+  const override = process.env.SOCIAL_CLI_ARCHIVE_DIR || archiveDir
+  if (override && override.trim()) {
+    return isAbsolute(override) ? override : resolve(baseDir, override)
+  }
+  return resolve(baseDir, "outbox_archive")
+}
+
+/**
+ * Archive a platform-specific outbox file after dispatch. The archive
+ * directory is configurable (see `resolveArchiveDir`); defaults to
+ * `<stateDir>/outbox_archive` for backward compatibility.
  */
 export function archivePlatformOutbox(
   platform: string,
-  stateDir?: string
+  stateDir?: string,
+  archiveDir?: string
 ): string | null {
   const outboxPath = getPlatformFilePath("outbox", platform, stateDir)
   if (!existsSync(outboxPath)) return null
-  
-  const baseDir = stateDir ?? process.cwd()
-  const archiveDir = resolve(baseDir, "outbox_archive")
-  mkdirSync(archiveDir, { recursive: true })
-  
+
+  const archiveDirPath = resolveArchiveDir(stateDir, archiveDir)
+  mkdirSync(archiveDirPath, { recursive: true })
+
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
-  const archivedPath = join(archiveDir, `${timestamp}_outbox-${platform}.yaml`)
+  const archivedPath = join(archiveDirPath, `${timestamp}_outbox-${platform}.yaml`)
   
   // Use renameSync equivalent via copy + delete would be ideal
   // but for simplicity, we'll copy and let the caller handle deletion


### PR DESCRIPTION
## Problem

`dispatch` archives each sent outbox to a per-run `<timestamp>_outbox-<platform>.yaml` file, and the archive directory is hardcoded to `outbox_archive` (relative to `process.cwd()` in `dispatch.ts`, relative to `stateDir` in `state.ts`). Those files accumulate indefinitely. When the state directory is version-controlled — e.g. an agent/poller framework that git-tracks `inbox`/`outbox`/`sent_ledger` for disaster recovery — there's no way to keep the high-churn archive out of version control without forking the tool. (In one real deployment a single poller's `outbox_archive/` had ~330 files.)

Also surfaced while here: `loadConfig()` silently dropped the `state` and `dispatch` blocks (returned only `{accounts, sync}`), so `state.stateDir` / `state.platformIsolation` were **dead config** even though `dispatch` reads them — they only ever worked via the `cwd` default.

## Changes

- **`state.archiveDir` config + `SOCIAL_CLI_ARCHIVE_DIR` env var** (env takes precedence). Relative values resolve under `stateDir`/cwd; absolute used as-is. Default `"outbox_archive"` — **fully backward compatible**.
- New `resolveArchiveDir(stateDir?, archiveDir?)` helper; `archivePlatformOutbox` gains an optional `archiveDir` param.
- Wire `dispatch` to it — which also **fixes the archive there using `process.cwd()`** instead of the configured `stateDir` (the sibling inbox/outbox/ledger files already use `stateDir`; the archive was inconsistent).
- **Fix `loadConfig`** to return the `state` and `dispatch` blocks it was dropping.

## Tests

`src/lib/state.test.ts` covers `resolveArchiveDir` precedence (env > config > default), relative-vs-absolute resolution, and the default. `tsc` clean; full suite **70 passed**.

## Example

```yaml
state:
  stateDir: ./state
  archiveDir: outbox_archive   # or an absolute path outside version control
```
```bash
SOCIAL_CLI_ARCHIVE_DIR=/var/tmp/social-archive social-cli dispatch
```