### PR TITLE
Support alt text for media attachments

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -142,6 +142,10 @@ dispatch:
       platform: bsky
       id: "at://did:plc:xxx/app.bsky.feed.post/abc"
       text: "Great question. Here's what I think..."
+      media:
+        - /tmp/card.png
+      mediaAlt:
+        - "A small card with the reply's main point"
 
   # Post to one or more platforms
   - post:
@@ -166,6 +170,10 @@ dispatch:
         - "1/ I've been thinking about memory in AI systems."
         - "2/ The key insight is that persistence changes behavior."
         - "3/ When you remember, you commit. When you forget, you drift."
+      media:
+        - /tmp/thread-card.png
+      mediaAlt:
+        - "Title card for a thread about memory in AI systems"
 
   # Annotate a URL (Bluesky only, creates a margin annotation)
   - annotate:

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ dispatch:
       platform: bsky
       id: "at://did:plc:xxx/app.bsky.feed.post/abc"
       text: "Thanks for the mention"
+      media:
+        - /tmp/card.png
+      mediaAlt:
+        - "A small card reading: thanks for the mention"
 
   - post:
       text: "Hello from social-cli"
@@ -171,6 +175,10 @@ dispatch:
       posts:
         - "Thread post 1"
         - "Thread post 2"
+      media:
+        - /tmp/thread-card.png
+      mediaAlt:
+        - "Title card for the thread"
 
   - like:
       platform: bsky
@@ -242,7 +250,7 @@ The repo includes example scripts in `hooks/`:
 
 ### Bluesky + X
 
-The core social platforms. Post, reply, thread, like, follow, search, and read feeds. Character limits: 300 (Bluesky), 280 (X). Media attachments supported on both via `-m`.
+The core social platforms. Post, reply, thread, like, follow, search, and read feeds. Character limits: 300 (Bluesky), 280 (X). Media attachments supported on both via `-m`; provide accessibility descriptions with repeated `--media-alt` values in the same order as the media files.
 
 ### Semble
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,27 @@ function resolveUsersDir(): string | undefined {
   return undefined
 }
 
+function collectOption(value: string, previous: string[] = []): string[] {
+  previous.push(value)
+  return previous
+}
+
+function mediaOptions(opts: { media?: string[]; mediaAlt?: string[] }): { media?: string[]; mediaAlt?: string[] } {
+  const media = opts.media?.length ? opts.media : undefined
+  const mediaAlt = opts.mediaAlt?.length ? opts.mediaAlt : undefined
+
+  if (mediaAlt && !media) {
+    console.error("Error: --media-alt requires --media")
+    process.exit(1)
+  }
+  if (media && mediaAlt && mediaAlt.length > media.length) {
+    console.error(`Error: received ${mediaAlt.length} --media-alt value(s) for ${media.length} media file(s)`)
+    process.exit(1)
+  }
+
+  return { media, mediaAlt }
+}
+
 const program = new Command()
   .name("social-cli")
   .description("Agent-optimized social media CLI")
@@ -131,19 +152,21 @@ program
   .option("--quote <id>", "Quote/repost a post by ID")
   .option("--reply-to <id>", "Post as a reply to this post ID")
   .option("-m, --media <paths...>", "Media file paths to attach")
+  .option("--media-alt <text>", "Alt text for attached media; repeat to match media order", collectOption, [])
   .action(async (text, opts) => {
     const { validateText } = await import("./util/validate.js")
     validateText(opts.platform, text)
+    const media = mediaOptions(opts)
     const { getPlatformAsync } = await import("./platforms/index.js")
     const platform = await getPlatformAsync(opts.platform)
     if (opts.replyTo) {
-      const result = await platform.reply(opts.replyTo, text, { quoteId: opts.quote, media: opts.media })
+      const result = await platform.reply(opts.replyTo, text, { quoteId: opts.quote, ...media })
       console.log(`Posted (reply): ${result.id}`)
       const { pruneInboxByPostId } = await import("./lib/state.js")
       const pruned = pruneInboxByPostId(opts.platform, [opts.replyTo])
       if (pruned.length > 0) console.log(`Pruned ${pruned.length} inbox notification(s) matching reply target`)
     } else {
-      const result = await platform.post(text, { quoteId: opts.quote, media: opts.media })
+      const result = await platform.post(text, { quoteId: opts.quote, ...media })
       console.log(`Posted: ${result.id}`)
     }
   })
@@ -156,12 +179,14 @@ program
   .requiredOption("--id <id>", "Post ID to reply to")
   .option("-p, --platform <platform>", "Platform", "bsky")
   .option("-m, --media <paths...>", "Media file paths to attach")
+  .option("--media-alt <text>", "Alt text for attached media; repeat to match media order", collectOption, [])
   .action(async (text, opts) => {
     const { validateText } = await import("./util/validate.js")
     validateText(opts.platform, text)
+    const media = mediaOptions(opts)
     const { getPlatformAsync } = await import("./platforms/index.js")
     const platform = await getPlatformAsync(opts.platform)
-    const result = await platform.reply(opts.id, text, { media: opts.media })
+    const result = await platform.reply(opts.id, text, media)
     console.log(`Replied: ${result.id}`)
     const { pruneInboxByPostId } = await import("./lib/state.js")
     const pruned = pruneInboxByPostId(opts.platform, [opts.id])
@@ -175,16 +200,17 @@ program
   .argument("<posts...>", "Thread posts (each argument is one post)")
   .option("-p, --platform <platform>", "Platform", "bsky")
   .option("-m, --media <paths...>", "Media file paths to attach to first post")
+  .option("--media-alt <text>", "Alt text for attached media; repeat to match media order", collectOption, [])
   .action(async (posts, opts) => {
     const { validateTexts } = await import("./util/validate.js")
     validateTexts(opts.platform, posts)
 
-    const mediaPaths: string[] = opts.media ?? []
+    const media = mediaOptions(opts)
 
     const { getPlatformAsync } = await import("./platforms/index.js")
     const platform = await getPlatformAsync(opts.platform)
     const results = await platform.thread(posts, undefined, {
-      media: mediaPaths.length > 0 ? mediaPaths : undefined,
+      ...media,
     })
     for (const r of results) console.log(`Posted: ${r.id}`)
     console.log(`Thread: ${results.length} posts`)

--- a/src/commands/dispatch.test.ts
+++ b/src/commands/dispatch.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { stringify } from "yaml"
-import type { SocialPlatform } from "../platforms/types.js"
+import type { PostOpts, SocialPlatform, ThreadOpts } from "../platforms/types.js"
 
 const { runHooksMock, getPlatformAsyncMock } = vi.hoisted(() => ({
   runHooksMock: vi.fn(),
@@ -187,6 +187,64 @@ describe("dispatch hook alignment", () => {
         result: "success",
       },
     ])
+  })
+
+  it("passes media alt text through post and thread actions", async () => {
+    const bsky = createPlatform({
+      post: async (text: string, opts?: PostOpts) => {
+        expect(opts).toEqual({
+          media: ["/tmp/card.png"],
+          mediaAlt: ["Alt text for the card"],
+        })
+        return { platform: "bsky", id: "post-with-alt", uri: "at://post-with-alt", text }
+      },
+      thread: async (posts: string[], _replyTo?: string, opts?: ThreadOpts) => {
+        expect(opts).toEqual({
+          media: ["/tmp/thread-card.png"],
+          mediaAlt: ["Alt text for the thread card"],
+        })
+        return posts.map((text, idx) => ({
+          platform: "bsky",
+          id: `thread-with-alt-${idx + 1}`,
+          uri: `at://thread-with-alt-${idx + 1}`,
+          text,
+        }))
+      },
+    })
+
+    getPlatformAsyncMock.mockResolvedValue(bsky)
+
+    writeFileSync(
+      join(testDir, "outbox-bsky.yaml"),
+      stringify({
+        dispatch: [
+          {
+            post: {
+              platform: "bsky",
+              text: "Post with media alt",
+              media: ["/tmp/card.png"],
+              mediaAlt: ["Alt text for the card"],
+            },
+          },
+          {
+            thread: {
+              platform: "bsky",
+              posts: ["Thread with media alt"],
+              media: ["/tmp/thread-card.png"],
+              mediaAlt: ["Alt text for the thread card"],
+            },
+          },
+        ],
+      }),
+    )
+
+    await dispatch({ file: "outbox-bsky.yaml" })
+
+    const postDispatchEvents = runHooksMock.mock.calls
+      .filter(([, lifecycle]) => lifecycle === "postDispatch")
+      .map(([, , ctx]) => ctx.event)
+
+    expect(postDispatchEvents).toEqual(["post", "thread"])
   })
 
   it("fires onError hooks with the correct target platform for per-platform post failures", async () => {

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -510,6 +510,7 @@ async function dispatchPlatform(
         const plat = await getPlatformAsync(r.platform)
         const replyOpts: PostOpts = {}
         if (r.media && r.media.length > 0) replyOpts.media = r.media
+        if (r.mediaAlt && r.mediaAlt.length > 0) replyOpts.mediaAlt = r.mediaAlt
         const res = await plat.reply(r.id, r.text, replyOpts)
         results.push({ action: "reply", platform: r.platform, status: "ok", id: res.id, targetId: r.id })
         successfulReplyCount += 1
@@ -591,10 +592,14 @@ async function dispatchPlatform(
             // Route through reply when replyTo is specified
             const replyOpts: PostOpts = {}
             if (p.quoteId) replyOpts.quoteId = p.quoteId
+            if (p.media && p.media.length > 0) replyOpts.media = p.media
+            if (p.mediaAlt && p.mediaAlt.length > 0) replyOpts.mediaAlt = p.mediaAlt
             res = await plat.reply(p.replyTo, t.text, replyOpts)
           } else {
             const postOpts: PostOpts = {}
             if (p.quoteId) postOpts.quoteId = p.quoteId
+            if (p.media && p.media.length > 0) postOpts.media = p.media
+            if (p.mediaAlt && p.mediaAlt.length > 0) postOpts.mediaAlt = p.mediaAlt
             res = await plat.post(t.text, postOpts)
           }
           results.push({ action: "post", platform: t.platform, status: "ok", id: res.id })
@@ -639,10 +644,12 @@ async function dispatchPlatform(
       const threadResultStart = results.length
       try {
         const mediaPaths: string[] = t.media ?? []
+        const mediaAlt: string[] = t.mediaAlt ?? []
 
         const plat = await getPlatformAsync(t.platform)
         const res = await plat.thread(t.posts, t.replyTo, {
           media: mediaPaths.length > 0 ? mediaPaths : undefined,
+          mediaAlt: mediaAlt.length > 0 ? mediaAlt : undefined,
         })
         for (const r of res) {
           results.push({ action: "thread", platform: t.platform, status: "ok", id: r.id })

--- a/src/commands/validate.test.ts
+++ b/src/commands/validate.test.ts
@@ -49,4 +49,58 @@ describe("validateOutbox post actions", () => {
     expect(result.valid).toBe(false)
     expect(result.errors).toContain("Action 0: post cannot have both 'platform' and 'platforms'")
   })
+
+  it("accepts media alt text aligned with attached media", () => {
+    const result = validateOutbox({
+      dispatch: [
+        {
+          post: {
+            platform: "bsky",
+            text: "hello with media",
+            media: ["/tmp/card.png"],
+            mediaAlt: ["Card reading: hello with media"],
+          },
+        },
+      ],
+    })
+
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+    expect(result.warnings).toEqual([])
+  })
+
+  it("warns when media has no mediaAlt", () => {
+    const result = validateOutbox({
+      dispatch: [
+        {
+          thread: {
+            platform: "bsky",
+            posts: ["hello"],
+            media: ["/tmp/card.png"],
+          },
+        },
+      ],
+    })
+
+    expect(result.valid).toBe(true)
+    expect(result.warnings).toContain("Action 0: thread has media but no mediaAlt; attached images will post without alt text")
+  })
+
+  it("rejects mediaAlt without media", () => {
+    const result = validateOutbox({
+      dispatch: [
+        {
+          reply: {
+            platform: "bsky",
+            id: "at://target",
+            text: "hello",
+            mediaAlt: ["orphan alt"],
+          },
+        },
+      ],
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain("Action 0: reply 'mediaAlt' requires 'media'")
+  })
 })

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -11,6 +11,7 @@ export interface OutboxAction {
     id: string
     text: string
     media?: string[]
+    mediaAlt?: string[]
     notificationId?: string
     idempotencyKey?: string
   }
@@ -18,6 +19,10 @@ export interface OutboxAction {
     text?: string
     platform?: string
     platforms?: string[] | Record<string, string>
+    /** Media file paths to attach. */
+    media?: string[]
+    /** Alt text for media attachments, aligned by index with `media`. */
+    mediaAlt?: string[]
     /** Embed this post as a quote (AT URI or tweet ID). */
     quoteId?: string
     /** Post as a reply to this URI (AT URI or tweet ID). */
@@ -31,6 +36,8 @@ export interface OutboxAction {
     replyTo?: string
     /** Media file paths to attach to the first post. */
     media?: string[]
+    /** Alt text for media attachments, aligned by index with `media`. */
+    mediaAlt?: string[]
     idempotencyKey?: string
   }
   annotate?: {
@@ -74,6 +81,37 @@ export interface ValidationResult {
   valid: boolean
   errors: string[]
   warnings: string[]
+}
+
+function validateMediaFields(
+  prefix: string,
+  label: string,
+  media: unknown,
+  mediaAlt: unknown,
+  errors: string[],
+  warnings: string[],
+): void {
+  if (media !== undefined && !Array.isArray(media)) {
+    errors.push(`${prefix}: ${label} 'media' must be an array of file paths`)
+  }
+  if (Array.isArray(media) && media.some((m) => typeof m !== "string" || m.trim() === "")) {
+    errors.push(`${prefix}: ${label} 'media' entries must be non-empty file paths`)
+  }
+  if (mediaAlt !== undefined && !Array.isArray(mediaAlt)) {
+    errors.push(`${prefix}: ${label} 'mediaAlt' must be an array of alt text strings`)
+  }
+  if (Array.isArray(mediaAlt) && mediaAlt.some((m) => typeof m !== "string" || m.trim() === "")) {
+    errors.push(`${prefix}: ${label} 'mediaAlt' entries must be non-empty strings`)
+  }
+  if (Array.isArray(mediaAlt) && mediaAlt.length > 0 && !Array.isArray(media)) {
+    errors.push(`${prefix}: ${label} 'mediaAlt' requires 'media'`)
+  }
+  if (Array.isArray(media) && Array.isArray(mediaAlt) && mediaAlt.length > media.length) {
+    errors.push(`${prefix}: ${label} has ${mediaAlt.length} mediaAlt value(s) for ${media.length} media file(s)`)
+  }
+  if (Array.isArray(media) && media.length > 0 && (!Array.isArray(mediaAlt) || mediaAlt.length === 0)) {
+    warnings.push(`${prefix}: ${label} has media but no mediaAlt; attached images will post without alt text`)
+  }
 }
 
 export function validateOutbox(outbox: OutboxFile): ValidationResult {
@@ -120,12 +158,7 @@ export function validateOutbox(outbox: OutboxFile): ValidationResult {
       if (!r.platform) errors.push(`${prefix}: reply missing 'platform'`)
       if (!r.id) errors.push(`${prefix}: reply missing 'id'`)
       if (!r.text) errors.push(`${prefix}: reply missing 'text'`)
-      if (r.media !== undefined && !Array.isArray(r.media)) {
-        errors.push(`${prefix}: reply 'media' must be an array of file paths`)
-      }
-      if (Array.isArray(r.media) && r.media.some((m) => typeof m !== "string" || m.trim() === "")) {
-        errors.push(`${prefix}: reply 'media' entries must be non-empty file paths`)
-      }
+      validateMediaFields(prefix, "reply", r.media, r.mediaAlt, errors, warnings)
       if (r.platform && r.text) {
         const limit = PLATFORM_LIMITS[r.platform]
         if (limit && r.text.length > limit.chars) {
@@ -145,6 +178,7 @@ export function validateOutbox(outbox: OutboxFile): ValidationResult {
       if (p.quoteId && p.replyTo) {
         errors.push(`${prefix}: post cannot have both 'quoteId' and 'replyTo'`)
       }
+      validateMediaFields(prefix, "post", p.media, p.mediaAlt, errors, warnings)
       // Validate char limits for each platform
       if (p.text && p.platform) {
         const limit = PLATFORM_LIMITS[p.platform]
@@ -176,6 +210,7 @@ export function validateOutbox(outbox: OutboxFile): ValidationResult {
       if (!t.posts || !Array.isArray(t.posts) || t.posts.length === 0) {
         errors.push(`${prefix}: thread needs non-empty 'posts' array`)
       }
+      validateMediaFields(prefix, "thread", t.media, t.mediaAlt, errors, warnings)
       if (t.platform && t.posts) {
         const limit = PLATFORM_LIMITS[t.platform]
         if (limit) {

--- a/src/platforms/bluesky.ts
+++ b/src/platforms/bluesky.ts
@@ -286,10 +286,11 @@ function readJpegDimensions(buf: Buffer): { width: number; height: number } | un
 /**
  * Upload media files to Bluesky and return embed structure.
  */
-async function uploadMedia(agent: Agent, mediaPaths: string[]): Promise<any> {
+async function uploadMedia(agent: Agent, mediaPaths: string[], mediaAlt: string[] = []): Promise<any> {
   const images: Array<{ alt: string; image: any; aspectRatio?: { width: number; height: number } }> = []
 
-  for (const path of mediaPaths) {
+  for (let idx = 0; idx < mediaPaths.length; idx++) {
+    const path = mediaPaths[idx]
     const ext = extname(path).toLowerCase()
     const mimeTypes: Record<string, string> = {
       ".jpg": "image/jpeg",
@@ -318,7 +319,7 @@ async function uploadMedia(agent: Agent, mediaPaths: string[]): Promise<any> {
     }
 
     images.push({
-      alt: "",
+      alt: mediaAlt[idx] ?? "",
       image: blob.data.blob,
       ...(aspectRatio ? { aspectRatio } : {}),
     })
@@ -352,7 +353,7 @@ export const bluesky: SocialPlatform = {
 
       // Handle media uploads
       if (opts?.media && opts.media.length > 0) {
-        const mediaEmbed = await uploadMedia(agent, opts.media)
+        const mediaEmbed = await uploadMedia(agent, opts.media, opts.mediaAlt)
         if (mediaEmbed) {
           if (embed) {
             // Combine quote + media
@@ -388,7 +389,7 @@ export const bluesky: SocialPlatform = {
       // Handle media uploads
       let embed: any = undefined
       if (opts?.media && opts.media.length > 0) {
-        embed = await uploadMedia(agent, opts.media)
+        embed = await uploadMedia(agent, opts.media, opts.mediaAlt)
       }
 
       const res = await agent.post({
@@ -432,7 +433,7 @@ export const bluesky: SocialPlatform = {
 
       // Attach media to the first post only
       if (idx === 0 && opts?.media && opts.media.length > 0) {
-        postData.embed = await uploadMedia(agent, opts.media)
+        postData.embed = await uploadMedia(agent, opts.media, opts.mediaAlt)
       }
 
       const res = await withRetry(() => agent.post(postData))

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -8,6 +8,8 @@ export interface PostOpts {
   quoteId?: string
   /** Media attachment paths. */
   media?: string[]
+  /** Alt text for media attachments, aligned by index with `media`. */
+  mediaAlt?: string[]
 }
 
 export interface PostResult {
@@ -20,6 +22,8 @@ export interface PostResult {
 export interface ThreadOpts {
   /** Media file paths to attach to the first post. */
   media?: string[]
+  /** Alt text for media attachments, aligned by index with `media`. */
+  mediaAlt?: string[]
 }
 
 export interface AnnotateOpts {

--- a/src/platforms/x.ts
+++ b/src/platforms/x.ts
@@ -161,14 +161,19 @@ import type { SendTweetV2Params } from "twitter-api-v2"
 type MediaIds = NonNullable<NonNullable<SendTweetV2Params["media"]>["media_ids"]>
 
 /** Upload media files to X via v1 API and return media IDs for v2 tweets. */
-async function uploadMediaX(client: TwitterApi, mediaPaths: string[]): Promise<MediaIds | undefined> {
+async function uploadMediaX(client: TwitterApi, mediaPaths: string[], mediaAlt: string[] = []): Promise<MediaIds | undefined> {
   // X allows 1-4 media per tweet
   const paths = mediaPaths.slice(0, 4)
   if (paths.length === 0) return undefined
 
   const mediaIds: string[] = []
-  for (const filePath of paths) {
+  for (let idx = 0; idx < paths.length; idx++) {
+    const filePath = paths[idx]
     const mediaId = await withRetry(() => client.v1.uploadMedia(filePath))
+    const altText = mediaAlt[idx]
+    if (altText) {
+      await withRetry(() => client.v1.createMediaMetadata(mediaId, { alt_text: { text: altText } }))
+    }
     mediaIds.push(mediaId)
   }
 
@@ -183,7 +188,7 @@ export const x: SocialPlatform = {
     const client = getClient()
 
     const mediaIds = opts?.media && opts.media.length > 0
-      ? await uploadMediaX(client, opts.media) : undefined
+      ? await uploadMediaX(client, opts.media, opts.mediaAlt) : undefined
 
     const res = await withRetry(() =>
       client.v2.tweet(text, mediaIds ? { media: { media_ids: mediaIds } } : undefined),
@@ -199,7 +204,7 @@ export const x: SocialPlatform = {
     const client = getClient()
 
     const mediaIds = opts?.media && opts.media.length > 0
-      ? await uploadMediaX(client, opts.media) : undefined
+      ? await uploadMediaX(client, opts.media, opts.mediaAlt) : undefined
 
     const res = await withRetry(() =>
       client.v2.reply(text, targetId, mediaIds ? { media: { media_ids: mediaIds } } : undefined),
@@ -218,7 +223,7 @@ export const x: SocialPlatform = {
 
     // Upload media once, attach to first post only
     const mediaIds = opts?.media && opts.media.length > 0
-      ? await uploadMediaX(client, opts.media) : undefined
+      ? await uploadMediaX(client, opts.media, opts.mediaAlt) : undefined
 
     for (let idx = 0; idx < posts.length; idx++) {
       const text = posts[idx]


### PR DESCRIPTION
## Summary
- add repeatable `--media-alt` support to `post`, `reply`, and `thread`, aligned with `-m/--media`
- plumb `mediaAlt` through dispatch outboxes for reply/post/thread actions with validation for missing or misaligned alt text
- write alt text to Bluesky image embeds and X media metadata when media alt text is provided

## Validation
- `bun run tsc --noEmit`
- `bun run test`

👾 Generated with [Letta Code](https://letta.com)