### PR TITLE
Document read output shapes and add normalizer

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -295,7 +295,22 @@ social-cli whoami
 social-cli rate-limits
 ```
 
-All research commands output YAML to stdout (except `feed` which defaults to `feed.yaml` — use `-o -` for stdout).
+All research commands output YAML to stdout (except `feed` which defaults to `feed.yaml` — use `-o -` for stdout). `feed`, `search`, and `posts` return a bare YAML array of items. Inbox/state files return mappings such as `notifications:`. Agent helper scripts must normalize the parsed YAML root before accessing keys:
+
+```python
+root = yaml.safe_load(text) or []
+if isinstance(root, list):
+    items = root
+elif isinstance(root, dict):
+    items = next(
+        (root[key] for key in ("notifications", "posts", "results", "items", "feed") if isinstance(root.get(key), list)),
+        [],
+    )
+else:
+    items = []
+```
+
+Do not assume every parsed social-cli YAML value has `.get(...)`; bare arrays from read commands will fail that pattern.
 
 ## Character Limits
 

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -295,7 +295,19 @@ social-cli whoami
 social-cli rate-limits
 ```
 
-All research commands output YAML to stdout (except `feed` which defaults to `feed.yaml` — use `-o -` for stdout). `feed`, `search`, and `posts` return a bare YAML array of items. Inbox/state files return mappings such as `notifications:`. Agent helper scripts must normalize the parsed YAML root before accessing keys:
+All research commands output YAML to stdout (except `feed` which defaults to `feed.yaml` — use `-o -` for stdout). `feed`, `search`, and `posts` return a bare YAML array of items. Inbox/state files return mappings such as `notifications:`. Agent helper scripts must normalize the parsed YAML root before accessing keys.
+
+TypeScript helpers inside this repo can use the shared normalizer:
+
+```ts
+import { parse } from "yaml"
+import { normalizeReadOutputItems } from "./util/read-output.js"
+
+const root = parse(stdout)
+const items = normalizeReadOutputItems(root)
+```
+
+Python helpers should use the same shape check explicitly:
 
 ```python
 root = yaml.safe_load(text) or []

--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ social-cli rate-limits                       # rate limit status
 
 All read commands output YAML to stdout (except `feed` which defaults to a file). `feed`, `search`, and `posts` emit a bare YAML array of items; state files such as `inbox-{platform}.yaml` emit mappings like `notifications:`. Consumers should normalize the YAML root before reading keys: use the array directly when `Array.isArray(root)`, and only then fall back to keyed arrays such as `notifications`, `posts`, `results`, `items`, or `feed`.
 
+For TypeScript helpers inside this repo, use the normalizer instead of assuming a mapping root:
+
+```ts
+import { parse } from "yaml"
+import { normalizeReadOutputItems } from "./util/read-output.js"
+
+const root = parse(stdout)
+const items = normalizeReadOutputItems(root)
+```
+
 ## Outbox format
 
 Agents write decisions to `outbox-{platform}.yaml` in the active state directory for dispatch:

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ social-cli whoami                            # your account info (all platforms)
 social-cli rate-limits                       # rate limit status
 ```
 
-All read commands output YAML to stdout (except `feed` which defaults to a file).
+All read commands output YAML to stdout (except `feed` which defaults to a file). `feed`, `search`, and `posts` emit a bare YAML array of items; state files such as `inbox-{platform}.yaml` emit mappings like `notifications:`. Consumers should normalize the YAML root before reading keys: use the array directly when `Array.isArray(root)`, and only then fall back to keyed arrays such as `notifications`, `posts`, `results`, `items`, or `feed`.
 
 ## Outbox format
 

--- a/src/util/read-output.test.ts
+++ b/src/util/read-output.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import { normalizeReadOutputItems } from "./read-output.js"
+
+describe("normalizeReadOutputItems", () => {
+  it("returns bare arrays from feed/search/posts output", () => {
+    const items = [{ id: "post-1" }, { id: "post-2" }]
+
+    expect(normalizeReadOutputItems(items)).toEqual(items)
+  })
+
+  it("returns notifications from inbox mappings", () => {
+    const notifications = [{ id: "notif-1" }]
+
+    expect(normalizeReadOutputItems({ notifications, _sync: { cursor: "abc" } })).toEqual(notifications)
+  })
+
+  it("returns posts/results/items/feed arrays from wrapped mappings", () => {
+    expect(normalizeReadOutputItems({ posts: [{ id: "post-1" }] })).toEqual([{ id: "post-1" }])
+    expect(normalizeReadOutputItems({ results: [{ id: "result-1" }] })).toEqual([{ id: "result-1" }])
+    expect(normalizeReadOutputItems({ items: [{ id: "item-1" }] })).toEqual([{ id: "item-1" }])
+    expect(normalizeReadOutputItems({ feed: [{ id: "feed-1" }] })).toEqual([{ id: "feed-1" }])
+  })
+
+  it("returns an empty list for missing or non-array item fields", () => {
+    expect(normalizeReadOutputItems(undefined)).toEqual([])
+    expect(normalizeReadOutputItems(null)).toEqual([])
+    expect(normalizeReadOutputItems("not yaml data")).toEqual([])
+    expect(normalizeReadOutputItems({ notifications: { id: "wrong-shape" } })).toEqual([])
+    expect(normalizeReadOutputItems({ _sync: { cursor: "abc" } })).toEqual([])
+  })
+
+  it("supports explicit key priority for custom helpers", () => {
+    const root = {
+      primary: [{ id: "primary" }],
+      notifications: [{ id: "notification" }],
+    }
+
+    expect(normalizeReadOutputItems(root, ["primary", "notifications"])).toEqual([{ id: "primary" }])
+  })
+})

--- a/src/util/read-output.ts
+++ b/src/util/read-output.ts
@@ -1,0 +1,25 @@
+const DEFAULT_ITEM_KEYS = ["notifications", "posts", "results", "items", "feed"] as const
+
+/**
+ * Normalize YAML parsed from social-cli read/state commands into an item list.
+ *
+ * Read commands such as `feed`, `search`, and `posts` emit bare YAML arrays.
+ * State files such as inboxes emit mappings like `{ notifications: [...] }`.
+ * Agent helper scripts should normalize the root type before reading keyed fields
+ * so an array root never crashes with an unsafe `.get`/property lookup pattern.
+ */
+export function normalizeReadOutputItems<T = unknown>(
+  root: unknown,
+  itemKeys: readonly string[] = DEFAULT_ITEM_KEYS,
+): T[] {
+  if (Array.isArray(root)) return root as T[]
+  if (!root || typeof root !== "object") return []
+
+  const record = root as Record<string, unknown>
+  for (const key of itemKeys) {
+    const value = record[key]
+    if (Array.isArray(value)) return value as T[]
+  }
+
+  return []
+}


### PR DESCRIPTION
## Summary
- Add `normalizeReadOutputItems(...)` for bare-array read outputs and keyed state-file outputs
- Document the `feed`/`search`/`posts` YAML shape distinction in README and AGENT_GUIDE
- Add TypeScript and Python normalization examples so agent/helper consumers do not assume a mapping root
- Add focused tests for array roots, wrapped mappings, and bad shapes

## Validation
- `npm exec --yes pnpm@10.20.0 exec vitest run src/util/read-output.test.ts src/util/yaml.test.ts`
- `npm exec --yes pnpm@10.20.0 exec tsc --noEmit`

👾 Generated with [Letta Code](https://letta.com)
