### PR TITLE
Add own-replies inbox sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ social-cli search "query" -p x -n 10        # works on X too
 social-cli feed -p bsky -n 20               # timeline → feed.yaml (or -o - for stdout)
 social-cli feed --feed "at://did:.../app.bsky.feed.generator/name" -n 10  # custom feed
 social-cli posts alice.bsky.social -n 10     # user's recent posts → stdout YAML
+social-cli inbox own-replies -p bsky --unhandled  # replies under your own recent posts → stdout YAML
 social-cli profile alice.bsky.social         # user profile → stdout YAML
 social-cli whoami                            # your account info (all platforms)
 social-cli rate-limits                       # rate limit status
@@ -156,6 +157,33 @@ import { normalizeReadOutputItems } from "./util/read-output.js"
 const root = parse(stdout)
 const items = normalizeReadOutputItems(root)
 ```
+
+### Own-post reply sweeps
+
+Platform notification APIs do not always surface every reply to your own posts,
+especially non-mention replies. `inbox own-replies` scans recent posts by the
+authenticated account, follows threads/conversations with replies, and returns
+external replies as normal notification-shaped YAML with `type: own_reply`:
+
+```bash
+social-cli inbox own-replies -p bsky -p x --unhandled -n 12
+```
+
+Use `--write` to merge those generated notifications into the active platform
+inboxes so the standard agent loop can decide and `dispatch` can mark them
+processed:
+
+```bash
+social-cli inbox own-replies -p bsky -p x --unhandled --write --quiet
+social-cli check || exit 0
+# agent reads stateDir/inbox-{platform}.yaml and writes outbox decisions
+social-cli dispatch
+```
+
+`--unhandled` filters replies already recorded in `processed-{platform}.yaml` or
+`sent_ledger-{platform}.yaml`; existing inbox items are not duplicated when
+`--write` is used. `--depth` controls nested Bluesky thread traversal, and
+`--max-replies` caps generated items per platform.
 
 ## Outbox format
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -110,6 +110,70 @@ program
     await check({ threshold: parseInt(opts.threshold), platform: opts.platform })
   })
 
+// inbox: Generate/inspect inbox surfaces beyond ordinary notifications.
+const inbox = new Command("inbox")
+  .description("Inspect or populate generated inbox surfaces")
+
+inbox
+  .command("own-replies")
+  .description("Find external replies under recent posts by the authenticated account")
+  .option("-p, --platform <platform>", "Platform to scan; repeat for multiple (default: all)", collectOption, [])
+  .option("--handle <handle>", "Account handle/username to scan (default: authenticated account)")
+  .option("-n, --limit <number>", "Recent account-owned posts to scan per platform", "12")
+  .option("--max-replies <number>", "Maximum replies to return per platform", "100")
+  .option("--depth <number>", "Thread depth for platforms with nested replies", "5")
+  .option("--unhandled", "Filter out replies already present in processed/sent ledgers")
+  .option("--write", "Merge found replies into stateDir/inbox-{platform}.yaml")
+  .option("--quiet", "Suppress output when no replies are found or written")
+  .option("-o, --output <file>", "Output YAML file when not using --write; use - for stdout", "-")
+  .option("--state-dir <path>", "Override state directory")
+  .action(async (opts) => {
+    const { ownRepliesInboxCommand } = await import("./commands/inbox.js")
+    await ownRepliesInboxCommand({
+      platforms: opts.platform,
+      handle: opts.handle,
+      limit: parseInt(opts.limit),
+      repliesLimit: parseInt(opts.maxReplies),
+      depth: parseInt(opts.depth),
+      unhandled: opts.unhandled,
+      write: opts.write,
+      quiet: opts.quiet,
+      output: opts.output,
+      stateDir: opts.stateDir,
+    })
+  })
+
+program.addCommand(inbox)
+
+program
+  .command("own-replies")
+  .description("Alias for `inbox own-replies`")
+  .option("-p, --platform <platform>", "Platform to scan; repeat for multiple (default: all)", collectOption, [])
+  .option("--handle <handle>", "Account handle/username to scan (default: authenticated account)")
+  .option("-n, --limit <number>", "Recent account-owned posts to scan per platform", "12")
+  .option("--max-replies <number>", "Maximum replies to return per platform", "100")
+  .option("--depth <number>", "Thread depth for platforms with nested replies", "5")
+  .option("--unhandled", "Filter out replies already present in processed/sent ledgers")
+  .option("--write", "Merge found replies into stateDir/inbox-{platform}.yaml")
+  .option("--quiet", "Suppress output when no replies are found or written")
+  .option("-o, --output <file>", "Output YAML file when not using --write; use - for stdout", "-")
+  .option("--state-dir <path>", "Override state directory")
+  .action(async (opts) => {
+    const { ownRepliesInboxCommand } = await import("./commands/inbox.js")
+    await ownRepliesInboxCommand({
+      platforms: opts.platform,
+      handle: opts.handle,
+      limit: parseInt(opts.limit),
+      repliesLimit: parseInt(opts.maxReplies),
+      depth: parseInt(opts.depth),
+      unhandled: opts.unhandled,
+      write: opts.write,
+      quiet: opts.quiet,
+      output: opts.output,
+      stateDir: opts.stateDir,
+    })
+  })
+
 // search: Search posts
 program
   .command("search")

--- a/src/commands/inbox.test.ts
+++ b/src/commands/inbox.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { parse, stringify } from "yaml"
+import type { OwnPostReply, SocialPlatform } from "../platforms/types.js"
+
+const { getPlatformAsyncMock, availablePlatformsMock } = vi.hoisted(() => ({
+  getPlatformAsyncMock: vi.fn(),
+  availablePlatformsMock: vi.fn(),
+}))
+
+vi.mock("../platforms/index.js", () => ({
+  getPlatformAsync: getPlatformAsyncMock,
+  availablePlatforms: availablePlatformsMock,
+}))
+
+import { ownPostReplyToNotification, ownRepliesInbox } from "./inbox.js"
+
+function createPlatform(replies: OwnPostReply[]): SocialPlatform {
+  return {
+    name: "bsky",
+    post: async () => { throw new Error("post not implemented") },
+    reply: async () => { throw new Error("reply not implemented") },
+    thread: async () => { throw new Error("thread not implemented") },
+    notifications: async () => ({ notifications: [] }),
+    search: async () => [],
+    feed: async () => [],
+    rateLimitStatus: async () => ({ platform: "bsky", remaining: 0, limit: 0, resetsAt: new Date(0).toISOString() }),
+    ownPostReplies: async () => replies,
+  }
+}
+
+describe("inbox own-replies", () => {
+  const originalCwd = process.cwd()
+  let testDir: string
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "social-cli-own-replies-test-"))
+    process.chdir(testDir)
+    writeFileSync(join(testDir, "config.yaml"), stringify({ accounts: {}, state: { stateDir: "state" } }))
+    getPlatformAsyncMock.mockReset()
+    availablePlatformsMock.mockReset()
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it("converts own-post replies to normal notifications", () => {
+    expect(ownPostReplyToNotification({
+      platform: "bsky",
+      id: "at://reply",
+      author: "alice.example",
+      authorId: "did:plc:alice",
+      text: "hello",
+      timestamp: "2026-01-01T00:00:00Z",
+      ownPostId: "at://own/post",
+      ownPostText: "root",
+      rootId: "at://own/post",
+      parentId: "at://own/post",
+      parentAuthor: "void.example",
+      threadContext: [{ id: "at://own/post", author: "void.example", text: "root" }],
+    })).toEqual({
+      id: "at://reply",
+      platform: "bsky",
+      type: "own_reply",
+      author: "alice.example",
+      authorId: "did:plc:alice",
+      postId: "at://reply",
+      text: "hello",
+      timestamp: "2026-01-01T00:00:00Z",
+      threadContext: [{ author: "void.example", text: "root" }],
+      embed: undefined,
+      ownPostId: "at://own/post",
+      ownPostText: "root",
+      rootId: "at://own/post",
+      parentId: "at://own/post",
+      parentAuthor: "void.example",
+    })
+  })
+
+  it("filters handled replies and merges new ones into the platform inbox", async () => {
+    const replies: OwnPostReply[] = [
+      {
+        platform: "bsky",
+        id: "at://reply/processed",
+        author: "alice.example",
+        text: "already handled",
+        timestamp: "2026-01-01T00:00:00Z",
+        ownPostId: "at://own/one",
+      },
+      {
+        platform: "bsky",
+        id: "at://reply/existing",
+        author: "bob.example",
+        text: "already in inbox",
+        timestamp: "2026-01-01T00:00:01Z",
+        ownPostId: "at://own/two",
+      },
+      {
+        platform: "bsky",
+        id: "at://reply/new",
+        author: "carol.example",
+        text: "new reply",
+        timestamp: "2026-01-01T00:00:02Z",
+        ownPostId: "at://own/three",
+        parentId: "at://own/three",
+      },
+    ]
+    getPlatformAsyncMock.mockResolvedValue(createPlatform(replies))
+
+    mkdirSync(join(testDir, "state"), { recursive: true })
+    writeFileSync(join(testDir, "state", "processed-bsky.yaml"), stringify({ processed: ["at://reply/processed"] }))
+    writeFileSync(join(testDir, "state", "sent_ledger-bsky.yaml"), stringify({
+      entries: [{ createdId: "at://own/three" }],
+    }))
+    writeFileSync(join(testDir, "state", "inbox-bsky.yaml"), stringify({
+      notifications: [ownPostReplyToNotification(replies[1])],
+      _sync: { platform: "bsky", totalCount: 1 },
+    }))
+
+    const result = await ownRepliesInbox({ platforms: ["bsky"], unhandled: true, write: true, stateDir: "state" })
+
+    expect(result.results).toMatchObject([
+      {
+        platform: "bsky",
+        added: 1,
+        alreadyInInbox: 1,
+        skippedProcessed: 1,
+      },
+    ])
+    expect(result.notifications.map((n) => n.id)).toEqual(["at://reply/existing", "at://reply/new"])
+
+    const inbox = parse(readFileSync(join(testDir, "state", "inbox-bsky.yaml"), "utf-8"))
+    expect(inbox.notifications.map((n: any) => n.id)).toEqual(["at://reply/existing", "at://reply/new"])
+    expect(inbox._sync).toMatchObject({ source: "own-replies", newCount: 1, totalCount: 2 })
+  })
+
+  it("uses all available platforms by default", async () => {
+    availablePlatformsMock.mockReturnValue(["bsky"])
+    getPlatformAsyncMock.mockResolvedValue(createPlatform([]))
+
+    await ownRepliesInbox({ stateDir: "state" })
+
+    expect(getPlatformAsyncMock).toHaveBeenCalledWith("bsky")
+  })
+})

--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -1,0 +1,244 @@
+/**
+ * inbox: helpers for generated inbox surfaces that are not ordinary platform
+ * notifications. `own-replies` scans recent account-owned posts and turns
+ * external replies under those posts into normal inbox notifications.
+ */
+
+import { existsSync, readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { parse, stringify } from "yaml"
+import { getPlatformAsync, availablePlatforms } from "../platforms/index.js"
+import type { Notification, OwnPostReply } from "../platforms/types.js"
+import { loadConfig } from "../config.js"
+import {
+  getPlatformFilePath,
+  readPlatformFile,
+  writePlatformFile,
+} from "../lib/state.js"
+
+interface InboxFile {
+  notifications?: Notification[]
+  _sync?: Record<string, unknown>
+}
+
+interface ProcessedFile {
+  processed?: string[]
+}
+
+interface SentLedgerFile {
+  entries?: Array<{
+    notificationId?: string
+    targetId?: string
+    createdId?: string
+  }>
+}
+
+export interface OwnRepliesInboxOpts {
+  platforms?: string[]
+  handle?: string
+  limit?: number
+  repliesLimit?: number
+  depth?: number
+  unhandled?: boolean
+  write?: boolean
+  quiet?: boolean
+  stateDir?: string
+}
+
+export interface OwnRepliesPlatformResult {
+  platform: string
+  notifications: Notification[]
+  added: number
+  skippedProcessed: number
+  alreadyInInbox: number
+  inboxPath?: string
+}
+
+export interface OwnRepliesResult {
+  results: OwnRepliesPlatformResult[]
+  notifications: Notification[]
+}
+
+function readYamlFile<T>(path: string): T | null {
+  if (!existsSync(path)) return null
+  try {
+    return parse(readFileSync(path, "utf-8")) as T
+  } catch {
+    return null
+  }
+}
+
+export function ownPostReplyToNotification(reply: OwnPostReply): Notification {
+  return {
+    id: reply.id,
+    platform: reply.platform,
+    type: "own_reply",
+    author: reply.author,
+    authorId: reply.authorId,
+    postId: reply.id,
+    text: reply.text,
+    timestamp: reply.timestamp || new Date().toISOString(),
+    threadContext: reply.threadContext?.map(({ author, text }) => ({ author, text })),
+    embed: reply.embed,
+    ownPostId: reply.ownPostId,
+    ownPostText: reply.ownPostText,
+    rootId: reply.rootId,
+    parentId: reply.parentId,
+    parentAuthor: reply.parentAuthor,
+  }
+}
+
+function loadHandledIds(platform: string, stateDir?: string): Set<string> {
+  const processedPath = getPlatformFilePath("processed", platform, stateDir)
+  const sentLedgerPath = getPlatformFilePath("sent_ledger", platform, stateDir)
+  const handled = new Set<string>()
+
+  const processed = readYamlFile<ProcessedFile>(processedPath)
+  for (const id of processed?.processed ?? []) handled.add(id)
+
+  const ledger = readYamlFile<SentLedgerFile>(sentLedgerPath)
+  for (const entry of ledger?.entries ?? []) {
+    if (entry.notificationId) handled.add(entry.notificationId)
+    if (entry.targetId) handled.add(entry.targetId)
+    if (entry.createdId) handled.add(entry.createdId)
+  }
+
+  return handled
+}
+
+function notificationHandled(n: Notification, handled: Set<string>): boolean {
+  return handled.has(n.id) || handled.has(n.postId)
+}
+
+function mergeInbox(
+  platform: string,
+  notifications: Notification[],
+  stateDir?: string,
+): { added: number; alreadyInInbox: number; inboxPath: string } {
+  const inboxPath = getPlatformFilePath("inbox", platform, stateDir)
+  const existing = readPlatformFile<InboxFile>("inbox", platform, stateDir) ?? {}
+  const current = existing.notifications ?? []
+  const seen = new Set<string>()
+  for (const n of current) {
+    seen.add(n.id)
+    if (n.postId) seen.add(n.postId)
+  }
+
+  const additions = notifications.filter((n) => !seen.has(n.id) && !seen.has(n.postId))
+  const now = new Date().toISOString()
+  const nextNotifications = [...current, ...additions]
+
+  writePlatformFile<InboxFile>("inbox", platform, {
+    notifications: nextNotifications,
+    _sync: {
+      ...(existing._sync ?? {}),
+      timestamp: now,
+      platform,
+      source: "own-replies",
+      unreadOnly: false,
+      newCount: additions.length,
+      totalCount: nextNotifications.length,
+    },
+  }, stateDir)
+
+  return {
+    added: additions.length,
+    alreadyInInbox: notifications.length - additions.length,
+    inboxPath,
+  }
+}
+
+export async function ownRepliesInbox(opts: OwnRepliesInboxOpts = {}): Promise<OwnRepliesResult> {
+  const config = loadConfig()
+  const platformIsolation = config.state?.platformIsolation ?? true
+  const stateDir = opts.stateDir ?? config.state?.stateDir
+  if (!platformIsolation && opts.write) {
+    // The command can still emit YAML in legacy shared-state mode, but merging
+    // cross-platform generated inboxes into one shared file is ambiguous.
+    throw new Error("inbox own-replies --write requires platform-isolated state")
+  }
+
+  const platforms = opts.platforms?.length ? opts.platforms : availablePlatforms()
+  const results: OwnRepliesPlatformResult[] = []
+  const allNotifications: Notification[] = []
+
+  for (const platformName of platforms) {
+    const platform = await getPlatformAsync(platformName)
+    if (!platform.ownPostReplies) {
+      results.push({
+        platform: platformName,
+        notifications: [],
+        added: 0,
+        skippedProcessed: 0,
+        alreadyInInbox: 0,
+      })
+      continue
+    }
+
+    const replies = await platform.ownPostReplies({
+      handle: opts.handle,
+      limit: opts.limit,
+      repliesLimit: opts.repliesLimit,
+      depth: opts.depth,
+    })
+    let notifications = replies.map(ownPostReplyToNotification)
+    let skippedProcessed = 0
+
+    if (opts.unhandled) {
+      const handled = loadHandledIds(platformName, stateDir)
+      const before = notifications.length
+      notifications = notifications.filter((n) => !notificationHandled(n, handled))
+      skippedProcessed = before - notifications.length
+    }
+
+    let added = 0
+    let alreadyInInbox = 0
+    let inboxPath: string | undefined
+    if (opts.write) {
+      const merged = mergeInbox(platformName, notifications, stateDir)
+      added = merged.added
+      alreadyInInbox = merged.alreadyInInbox
+      inboxPath = merged.inboxPath
+    }
+
+    results.push({
+      platform: platformName,
+      notifications,
+      added,
+      skippedProcessed,
+      alreadyInInbox,
+      inboxPath,
+    })
+    allNotifications.push(...notifications)
+  }
+
+  return { results, notifications: allNotifications }
+}
+
+export async function ownRepliesInboxCommand(opts: OwnRepliesInboxOpts & { output?: string } = {}): Promise<void> {
+  const result = await ownRepliesInbox(opts)
+
+  if (opts.write) {
+    const totalAdded = result.results.reduce((sum, item) => sum + item.added, 0)
+    if (opts.quiet && totalAdded === 0) return
+    process.stdout.write(stringify({ results: result.results.map((item) => ({
+      platform: item.platform,
+      count: item.notifications.length,
+      added: item.added,
+      alreadyInInbox: item.alreadyInInbox,
+      skippedProcessed: item.skippedProcessed,
+      inboxPath: item.inboxPath,
+    })) }, { lineWidth: 120 }))
+    return
+  }
+
+  if (opts.quiet && result.notifications.length === 0) return
+
+  const yaml = stringify(result.notifications, { lineWidth: 120 })
+  if (opts.output && opts.output !== "-") {
+    const { writeFileAtomic } = await import("../util/fs.js")
+    writeFileAtomic(resolve(process.cwd(), opts.output), yaml)
+  } else {
+    process.stdout.write(yaml)
+  }
+}

--- a/src/platforms/bluesky.test.ts
+++ b/src/platforms/bluesky.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest"
-import { extractEmbed } from "./bluesky.js"
+import { collectOwnPostRepliesFromBskyThread, extractEmbed } from "./bluesky.js"
 
 describe("extractEmbed", () => {
   it("returns undefined for missing or untyped input", () => {
@@ -182,5 +182,65 @@ describe("extractEmbed", () => {
 
   it("returns undefined for unrecognized embed types", () => {
     expect(extractEmbed({ $type: "app.bsky.embed.something.unknown" })).toBeUndefined()
+  })
+})
+
+describe("collectOwnPostRepliesFromBskyThread", () => {
+  const ownDid = "did:plc:own"
+
+  function post(uri: string, did: string, handle: string, text: string) {
+    return {
+      uri,
+      author: { did, handle },
+      record: { text },
+      indexedAt: "2026-01-01T00:00:00Z",
+    }
+  }
+
+  it("collects external replies under an own post and skips own thread children", () => {
+    const thread = {
+      post: post("at://own/root", ownDid, "void.example", "root post"),
+      replies: [
+        { post: post("at://alice/reply", "did:plc:alice", "alice.example", "first reply"), replies: [] },
+        {
+          post: post("at://own/followup", ownDid, "void.example", "own followup"),
+          replies: [
+            { post: post("at://bob/reply", "did:plc:bob", "bob.example", "nested reply"), replies: [] },
+          ],
+        },
+      ],
+    }
+
+    const replies = collectOwnPostRepliesFromBskyThread(
+      thread,
+      ownDid,
+      { id: "at://own/root", text: "root post" },
+    )
+
+    expect(replies.map((reply) => reply.id)).toEqual(["at://alice/reply", "at://bob/reply"])
+    expect(replies[0]).toMatchObject({
+      platform: "bsky",
+      author: "alice.example",
+      authorId: "did:plc:alice",
+      ownPostId: "at://own/root",
+      rootId: "at://own/root",
+      parentId: "at://own/root",
+      parentAuthor: "void.example",
+      threadContext: [{ id: "at://own/root", author: "void.example", text: "root post" }],
+    })
+    expect(replies[1].threadContext?.map((item) => item.id)).toEqual(["at://own/root", "at://own/followup"])
+  })
+
+  it("deduplicates by caller limit", () => {
+    const thread = {
+      post: post("at://own/root", ownDid, "void.example", "root post"),
+      replies: [
+        { post: post("at://alice/one", "did:plc:alice", "alice.example", "one"), replies: [] },
+        { post: post("at://bob/two", "did:plc:bob", "bob.example", "two"), replies: [] },
+      ],
+    }
+
+    expect(collectOwnPostRepliesFromBskyThread(thread, ownDid, undefined, 1).map((reply) => reply.id))
+      .toEqual(["at://alice/one"])
   })
 })

--- a/src/platforms/bluesky.ts
+++ b/src/platforms/bluesky.ts
@@ -22,6 +22,8 @@ import type {
   ThreadOpts,
   ProfileInfo,
   EmbedInfo,
+  OwnPostReply,
+  ThreadContextItem,
 } from "./types.js"
 import { loadConfig, loadCredentials } from "../config.js"
 import { withRetry } from "../util/retry.js"
@@ -281,6 +283,76 @@ function readJpegDimensions(buf: Buffer): { width: number; height: number } | un
     i += 2 + segLen
   }
   return undefined
+}
+
+interface BskyThreadNode {
+  post?: any
+  parent?: BskyThreadNode
+  replies?: BskyThreadNode[]
+}
+
+function postText(post: any): string {
+  return (post?.record as any)?.text ?? ""
+}
+
+function postTimestamp(post: any): string {
+  return post?.indexedAt ?? (post?.record as any)?.createdAt ?? ""
+}
+
+function contextEntryFromPost(post: any): ThreadContextItem {
+  return {
+    id: post?.uri,
+    author: post?.author?.handle ?? "unknown",
+    text: postText(post),
+  }
+}
+
+export function collectOwnPostRepliesFromBskyThread(
+  thread: BskyThreadNode | undefined,
+  ownDid: string,
+  scannedOwnPost?: { id: string; text?: string },
+  repliesLimit = 100,
+): OwnPostReply[] {
+  const replies: OwnPostReply[] = []
+  if (!thread?.post) return replies
+
+  const rootId = thread.post.uri
+  const ownPostId = scannedOwnPost?.id ?? rootId
+  const ownPostText = scannedOwnPost?.text ?? postText(thread.post)
+
+  const walk = (node: BskyThreadNode, ancestors: any[]): void => {
+    if (!node?.post || replies.length >= repliesLimit) return
+
+    const post = node.post
+    const uri = post.uri
+    const authorDid = post.author?.did
+
+    if (uri !== ownPostId && authorDid !== ownDid) {
+      const parent = ancestors[ancestors.length - 1]
+      replies.push({
+        platform: "bsky",
+        id: uri,
+        author: post.author?.handle ?? "unknown",
+        authorId: authorDid,
+        text: postText(post),
+        timestamp: postTimestamp(post),
+        ownPostId,
+        ownPostText,
+        rootId,
+        parentId: parent?.uri,
+        parentAuthor: parent?.author?.handle,
+        threadContext: ancestors.map(contextEntryFromPost),
+        embed: extractEmbed(post.embed),
+      })
+    }
+
+    for (const child of node.replies ?? []) {
+      walk(child, [...ancestors, post])
+    }
+  }
+
+  walk(thread, [])
+  return replies
 }
 
 /**
@@ -666,6 +738,56 @@ export const bluesky: SocialPlatform = {
         repostCount: item.post.repostCount ?? 0,
         embed: extractEmbed(item.post.embed),
       }))
+    })
+  },
+
+  async ownPostReplies(opts?: {
+    handle?: string
+    limit?: number
+    repliesLimit?: number
+    depth?: number
+  }): Promise<OwnPostReply[]> {
+    return withSession(async (agent) => {
+      const limit = opts?.limit ?? 12
+      const depth = opts?.depth ?? 5
+      const repliesLimit = opts?.repliesLimit ?? 100
+
+      const profile = opts?.handle
+        ? await agent.app.bsky.actor.getProfile({ actor: opts.handle.replace(/^@/, "") })
+        : await agent.app.bsky.actor.getProfile({ actor: agent.did! })
+      const handle = profile.data.handle
+      const ownDid = profile.data.did
+
+      const feed = await agent.app.bsky.feed.getAuthorFeed({ actor: handle, limit })
+      const ownPosts = feed.data.feed.map((item) => item.post)
+      const replies: OwnPostReply[] = []
+      const seen = new Set<string>()
+
+      for (const post of ownPosts) {
+        if (replies.length >= repliesLimit) break
+        if ((post.replyCount ?? 0) <= 0) continue
+
+        const threadRes = await agent.app.bsky.feed.getPostThread({
+          uri: post.uri,
+          depth,
+          parentHeight: 0,
+        })
+        const found = collectOwnPostRepliesFromBskyThread(
+          threadRes.data.thread as any,
+          ownDid,
+          { id: post.uri, text: postText(post) },
+          repliesLimit - replies.length,
+        )
+
+        for (const reply of found) {
+          if (seen.has(reply.id)) continue
+          seen.add(reply.id)
+          replies.push(reply)
+          if (replies.length >= repliesLimit) break
+        }
+      }
+
+      return replies
     })
   },
 

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -65,6 +65,13 @@ export interface Notification {
   userContext?: string
   media?: NotificationMedia[]
   embed?: EmbedInfo
+  /** For own-post reply sweeps: recent account-owned post that led to this reply. */
+  ownPostId?: string
+  ownPostText?: string
+  /** Thread/conversation root and direct parent when known. */
+  rootId?: string
+  parentId?: string
+  parentAuthor?: string
   /** True if the account owner has blocked this author. */
   blocked?: boolean
 }
@@ -113,6 +120,35 @@ export interface FeedItem {
   likeCount?: number
   replyCount?: number
   repostCount?: number
+  embed?: EmbedInfo
+}
+
+export interface ThreadContextItem {
+  id?: string
+  author: string
+  text: string
+}
+
+export interface OwnPostReply {
+  platform: string
+  /** Reply post/tweet id. */
+  id: string
+  /** Reply author handle/username when available. */
+  author: string
+  /** Permanent reply author id (DID for Bluesky, user id for X) when available. */
+  authorId?: string
+  text: string
+  timestamp: string
+  /** Recent own post/tweet that was scanned and led to this reply. */
+  ownPostId: string
+  ownPostText?: string
+  /** Thread/conversation root id when known. */
+  rootId?: string
+  /** Direct parent id when known. */
+  parentId?: string
+  parentAuthor?: string
+  /** Ancestors from the scanned own post down to the direct parent. */
+  threadContext?: ThreadContextItem[]
   embed?: EmbedInfo
 }
 
@@ -178,6 +214,13 @@ export interface SocialPlatform {
   profile?(handle: string): Promise<ProfileInfo>
   /** Fetch recent posts by a user. */
   userPosts?(handle: string, limit?: number): Promise<FeedItem[]>
+  /** Fetch external replies in threads under recent posts by this account. */
+  ownPostReplies?(opts?: {
+    handle?: string
+    limit?: number
+    repliesLimit?: number
+    depth?: number
+  }): Promise<OwnPostReply[]>
   /** Attach an annotation to a URL/post. Bluesky-specific. */
   annotate?(targetId: string, text: string, opts?: AnnotateOpts): Promise<PostResult>
   /** Follow a user by handle or DID. */

--- a/src/platforms/x.ts
+++ b/src/platforms/x.ts
@@ -17,6 +17,8 @@ import type {
   RateLimitInfo,
   ProfileInfo,
   ThreadOpts,
+  OwnPostReply,
+  ThreadContextItem,
 } from "./types.js"
 import { loadConfig, loadCredentials } from "../config.js"
 import { withRetry } from "../util/retry.js"
@@ -117,6 +119,35 @@ async function hydrateContextTweets(
   }
 }
 
+async function hydrateReplyAncestorChain(
+  client: TwitterApi,
+  tweets: Array<Pick<TweetV2, "referenced_tweets">>,
+  tweetsById: Map<string, XContextTweet>,
+  authors: Record<string, string>,
+): Promise<void> {
+  let frontier = [...new Set(
+    tweets
+      .map((tweet) => repliedToId(tweet))
+      .filter((id): id is string => Boolean(id)),
+  )]
+  const seen = new Set<string>()
+
+  for (let depth = 0; frontier.length > 0 && depth < MAX_THREAD_CONTEXT_DEPTH; depth++) {
+    const current = frontier.filter((id) => !seen.has(id))
+    if (current.length === 0) break
+    for (const id of current) seen.add(id)
+
+    await hydrateContextTweets(client, current, tweetsById, authors)
+
+    frontier = [...new Set(
+      current
+        .map((id) => tweetsById.get(id))
+        .map((tweet) => tweet ? repliedToId(tweet) : undefined)
+        .filter((id): id is string => Boolean(id)),
+    )]
+  }
+}
+
 function buildReplyContext(
   tweet: Pick<TweetV2, "referenced_tweets">,
   tweetsById: Map<string, XContextTweet>,
@@ -154,6 +185,33 @@ function buildThreadContext(
   }
 
   return context.map(({ author, text }) => ({ author, text }))
+}
+
+function buildThreadContextItems(
+  tweet: Pick<TweetV2, "referenced_tweets">,
+  tweetsById: Map<string, XContextTweet>,
+  authors: Record<string, string>,
+): ThreadContextItem[] {
+  return buildReplyContext(tweet, tweetsById, authors).map(({ id, author, text }) => ({ id, author, text }))
+}
+
+function chainContainsTweet(
+  tweet: Pick<TweetV2, "referenced_tweets">,
+  targetId: string,
+  tweetsById: Map<string, XContextTweet>,
+): boolean {
+  const seen = new Set<string>()
+  let currentId = repliedToId(tweet)
+
+  while (currentId && !seen.has(currentId)) {
+    if (currentId === targetId) return true
+    seen.add(currentId)
+    const current = tweetsById.get(currentId)
+    if (!current) break
+    currentId = repliedToId(current)
+  }
+
+  return false
 }
 
 import type { SendTweetV2Params } from "twitter-api-v2"
@@ -427,6 +485,88 @@ export const x: SocialPlatform = {
       replyCount: (t.public_metrics as any)?.reply_count ?? 0,
       repostCount: (t.public_metrics as any)?.retweet_count ?? 0,
     }))
+  },
+
+  async ownPostReplies(opts?: {
+    handle?: string
+    limit?: number
+    repliesLimit?: number
+  }): Promise<OwnPostReply[]> {
+    const client = getClient()
+    const limit = opts?.limit ?? 12
+    const repliesLimit = opts?.repliesLimit ?? 100
+
+    const cleanHandle = opts?.handle?.replace(/^@/, "")
+    const user = cleanHandle
+      ? await withRetry(() => client.v2.userByUsername(cleanHandle))
+      : await withRetry(() => client.v2.me())
+    if (!user.data) throw new Error(`User not found: ${opts?.handle ?? "authenticated account"}`)
+
+    const handle = user.data.username ?? cleanHandle ?? user.data.id
+    const ownUserId = user.data.id
+    const timeline = await withRetry(() => client.v2.userTimeline(ownUserId, {
+      max_results: Math.max(10, Math.min(limit, 100)),
+      "tweet.fields": ["created_at", "author_id", "conversation_id", "public_metrics", "referenced_tweets"],
+      expansions: ["author_id", "referenced_tweets.id", "referenced_tweets.id.author_id"],
+    }))
+
+    const authors: Record<string, string> = { [ownUserId]: handle }
+    addUsersToAuthorMap(authors, timeline.includes?.users)
+
+    const tweetsById = new Map<string, XContextTweet>()
+    addTweetsToMap(tweetsById, timeline.includes?.tweets)
+    addTweetsToMap(tweetsById, timeline.data?.data)
+
+    const replies: OwnPostReply[] = []
+    const seen = new Set<string>()
+
+    for (const ownTweet of timeline.data?.data ?? []) {
+      if (replies.length >= repliesLimit) break
+      const replyCount = (ownTweet.public_metrics as any)?.reply_count ?? 0
+      if (replyCount <= 0) continue
+
+      const conversationId = ownTweet.conversation_id ?? ownTweet.id
+      const searchLimit = Math.max(10, Math.min(repliesLimit, 100))
+      const result = await withRetry(() => client.v2.search(`conversation_id:${conversationId}`, {
+        max_results: searchLimit,
+        "tweet.fields": ["created_at", "author_id", "conversation_id", "referenced_tweets"],
+        expansions: ["author_id", "referenced_tweets.id", "referenced_tweets.id.author_id"],
+      }))
+
+      addUsersToAuthorMap(authors, result.includes?.users)
+      addTweetsToMap(tweetsById, result.includes?.tweets)
+      addTweetsToMap(tweetsById, result.data?.data)
+
+      const candidateTweets = result.data?.data ?? []
+      await hydrateReplyAncestorChain(client, candidateTweets, tweetsById, authors)
+
+      for (const tweet of candidateTweets) {
+        if (replies.length >= repliesLimit) break
+        if (tweet.id === ownTweet.id || tweet.author_id === ownUserId || seen.has(tweet.id)) continue
+        if (!chainContainsTweet(tweet, ownTweet.id, tweetsById)) continue
+
+        const parentId = repliedToId(tweet)
+        const parent = parentId ? tweetsById.get(parentId) : undefined
+        const context = buildThreadContextItems(tweet, tweetsById, authors)
+        replies.push({
+          platform: "x",
+          id: tweet.id,
+          author: authors[tweet.author_id ?? ""] ?? tweet.author_id ?? "unknown",
+          authorId: tweet.author_id,
+          text: tweet.text,
+          timestamp: tweet.created_at ?? "",
+          ownPostId: ownTweet.id,
+          ownPostText: ownTweet.text,
+          rootId: conversationId,
+          parentId,
+          parentAuthor: parent ? authors[parent.author_id ?? ""] : undefined,
+          threadContext: context,
+        })
+        seen.add(tweet.id)
+      }
+    }
+
+    return replies
   },
 
   async follow(handle: string): Promise<void> {


### PR DESCRIPTION
## Summary
- add `inbox own-replies` plus a top-level `own-replies` alias
- surface external replies under recent account-owned Bluesky/X posts as `own_reply` notifications
- support `--unhandled`, `--write`, `--quiet`, thread depth/reply caps, and README docs

## Validation
- `npm exec --yes pnpm@10.20.0 -- test --run`
- `npm exec --yes pnpm@10.20.0 -- build`
- live Bluesky smoke test with credentials: `node dist/cli.js inbox own-replies -p bsky --unhandled -n 3 --max-replies 10`