### PR TITLE
fix(publish): store raw markdown in site.standard.document textContent

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -532,22 +532,6 @@ function generateUuidV7(): string {
 }
 
 /**
- * Flatten page-blocks → plaintext for the document-level `textContent` field.
- * Used by indexers (leaflet-search etc.) for full-text search.
- */
-function blocksToTextContent(blocks: LeafletPageBlock[]): string {
-  return blocks
-    .map(({ block }) => {
-      if (block.$type === "pub.leaflet.blocks.image") {
-        return block.alt ?? ""
-      }
-      return block.plaintext
-    })
-    .filter(Boolean)
-    .join("\n")
-}
-
-/**
  * Parse YAML-ish frontmatter (key: value pairs only, no nested structures).
  * Reuses the same pattern as src/commands/blog.ts.
  */
@@ -702,7 +686,13 @@ async function publishDocument(opts: PublishOptions): Promise<PublishResult> {
   if (blocks.length === 0) {
     return { success: false, error: "No content blocks parsed from body" }
   }
-  const textContent = blocksToTextContent(blocks)
+  // Store the *source markdown* as `textContent` so downstream readers can
+  // render it at full fidelity — headings, lists, and fenced code blocks all
+  // survive. The leaflet `content` blocks (below) remain for appviews that
+  // render structured content, but markdown→block conversion is lossy (it
+  // flattens fenced code onto one line), so the raw markdown is the source of
+  // truth for consumers that render the record themselves.
+  const textContent = body
 
   // Tags array (comma-separated → trimmed array, drop empties)
   const tags = tagsRaw


### PR DESCRIPTION
## Problem

`publish` stores a lossy `textContent`. The markdown→`pub.leaflet.content`
conversion (`markdownToBlocks`) treats a fenced code block as an ordinary
paragraph and flattens it onto one line, then the inline parser renders it as
inline code. `textContent` was derived from those blocks (`blocksToTextContent`),
so any consumer that reads `textContent` — e.g. a site rendering the record
directly — loses all code-block formatting (and list/structure fidelity).

Concretely, a ```` ```json ```` block becomes a single-line `` `json { … } ` ``
inline-code blob in both the leaflet `content` and the `textContent`.

## Fix

Store the **source markdown** itself as `textContent`, so consumers that render
the record directly get full fidelity — headings, lists, and fenced code blocks
survive. The leaflet `content` blocks are unchanged and remain for appviews that
render structured content; markdown is simply the source of truth for
full-fidelity reads. Removes the now-unused `blocksToTextContent` flattener.

```diff
- const textContent = blocksToTextContent(blocks)
+ const textContent = body   // raw source markdown
```

## Verification

- `tsc` — clean
- `publish --file … --dry-run` on a doc with a fenced ```` ```json ```` block:
  `textContent` now contains the real `## heading`, the multi-line fenced code
  block, inline code, and markdown links (previously a flattened one-liner).
- Existing tests unaffected (the pre-existing `state.test.ts` failures are
  unrelated to this change).

## Notes

Backwards-compatible: `textContent` is optional and free-form; this only changes
what we put there. `content` (the leaflet blocks) is untouched, so leaflet.pub
rendering is unaffected.