### PR TITLE
fix: add --reply-to option to thread command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -265,6 +265,7 @@ program
   .option("-p, --platform <platform>", "Platform", "bsky")
   .option("-m, --media <paths...>", "Media file paths to attach to first post")
   .option("--media-alt <text>", "Alt text for attached media; repeat to match media order", collectOption, [])
+  .option("--reply-to <id>", "Post ID to reply to (roots the thread as a reply)")
   .action(async (posts, opts) => {
     const { validateTexts } = await import("./util/validate.js")
     validateTexts(opts.platform, posts)
@@ -273,7 +274,7 @@ program
 
     const { getPlatformAsync } = await import("./platforms/index.js")
     const platform = await getPlatformAsync(opts.platform)
-    const results = await platform.thread(posts, undefined, {
+    const results = await platform.thread(posts, opts.replyTo, {
       ...media,
     })
     for (const r of results) console.log(`Posted: ${r.id}`)


### PR DESCRIPTION
## Summary

- The `thread` CLI command was posting standalone top-level threads with no way to root them as a reply to an existing post
- The platform interface (`Platform.thread()`) already supported `replyTo` as its second parameter, but the CLI command was passing `undefined` instead of exposing the option
- This caused replies that needed multiple posts (exceeding platform char limits) to post as standalone threads instead of replies to the parent post

## Fix

Added `--reply-to <id>` option to the `thread` command. When provided, the thread roots as a reply to the specified post ID.

## Test plan

- [x] TypeScript compiles clean
- [x] `thread --help` shows the new option
- [ ] Manual test: `thread -p x --reply-to <tweet-id> "post1" "post2"` posts as a reply thread, not standalone
- [ ] Manual test: `thread -p bsky --reply-to <at-uri> "post1" "post2"` posts as a reply thread on Bluesky

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>